### PR TITLE
Add MCP Registry release publishing

### DIFF
--- a/.github/workflows/mcp-registry-release.yml
+++ b/.github/workflows/mcp-registry-release.yml
@@ -1,0 +1,119 @@
+name: MCP Registry Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: Release tag to publish, for example v1.2.0.
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.version_tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  NODE_VERSION: '22'
+  MCP_REGISTRY_SERVER_NAME: io.github.swimmwatch/cloakbrowser-mcp
+  MCP_REGISTRY_PACKAGE_NAME: cloakbrowser-mcp
+  MCP_REGISTRY_IMAGE_NAME: ghcr.io/swimmwatch/cloakbrowser-mcp
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    environment: mcp-registry-production
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.version_tag }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+
+      - run: npm ci --ignore-scripts
+
+      - id: release
+        name: Apply release version from tag
+        env:
+          RELEASE_VERSION_TAG: ${{ github.event.release.tag_name || inputs.version_tag }}
+        run: npm run version:apply -- "$RELEASE_VERSION_TAG"
+
+      - name: Wait for npm package
+        env:
+          PACKAGE_NAME: ${{ env.MCP_REGISTRY_PACKAGE_NAME }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          package="${PACKAGE_NAME}@${PACKAGE_VERSION}"
+          for attempt in $(seq 1 120); do
+            if npm view "$package" version >/dev/null 2>&1; then
+              echo "$package is available on npm"
+              exit 0
+            fi
+            echo "Waiting for $package on npm ($attempt/120)"
+            sleep 30
+          done
+          echo "::error title=npm package not available::$package was not visible after waiting"
+          exit 1
+
+      - name: Wait for Docker image
+        env:
+          IMAGE_REF: ${{ env.MCP_REGISTRY_IMAGE_NAME }}:${{ steps.release.outputs.docker_version }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 120); do
+            if docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
+              echo "$IMAGE_REF is available in GHCR"
+              exit 0
+            fi
+            echo "Waiting for $IMAGE_REF in GHCR ($attempt/120)"
+            sleep 30
+          done
+          echo "::error title=Docker image not available::$IMAGE_REF was not visible after waiting"
+          exit 1
+
+      - run: npm run server:validate
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Validate server metadata with mcp-publisher
+        run: ./mcp-publisher validate server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish server.json
+
+      - name: Verify registry entry
+        env:
+          SERVER_NAME: ${{ env.MCP_REGISTRY_SERVER_NAME }}
+          SERVER_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 20); do
+            response="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}")"
+            echo "$response" | jq .
+            count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[] | select(.name == $name and .version == $version)] | length')"
+            if [ "$count" = "1" ]; then
+              echo "$SERVER_NAME version $SERVER_VERSION is visible in the MCP Registry"
+              exit 0
+            fi
+            echo "Waiting for $SERVER_NAME version $SERVER_VERSION in the MCP Registry ($attempt/20)"
+            sleep 15
+          done
+          echo "::error title=MCP Registry verification failed::Could not find $SERVER_NAME version $SERVER_VERSION"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-27
+
+### Added
+
+- Added official MCP Registry publishing through `mcp-publisher` and GitHub Actions OIDC.
+
 ## [1.1.0] - 2026-05-24
 
 ### Added
@@ -66,7 +72,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generated configuration documentation based on the removed native config schema.
 - Public SEO setup guide and stale roadmap page from the published documentation.
 
-[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![NPM Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/npm-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/npm-release.yml)
 [![Docker Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docker-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docker-release.yml)
 [![Docs Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docs-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docs-release.yml)
+[![MCP Registry Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/mcp-registry-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/mcp-registry-release.yml)
 [![npm](https://img.shields.io/npm/v/cloakbrowser-mcp.svg?logo=npm)](https://www.npmjs.com/package/cloakbrowser-mcp)
 [![Node.js >=20](https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![MCP Server](https://img.shields.io/badge/MCP-server-000000)](https://modelcontextprotocol.io/)
@@ -35,6 +36,7 @@ The server is intentionally thin:
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base | CloakBrowser | Node.js | Transport | Platform | Parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.1.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.0.2` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.0.1` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 Pin a release when reproducibility matters:
 
 ```bash
-npx -y cloakbrowser-mcp@1.1.0
+npx -y cloakbrowser-mcp@1.2.0
 ```
 
 The npm package requires Node.js 20 or newer. CloakBrowser downloads its Chromium binary on first use unless it is already cached.
@@ -55,10 +55,10 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
 Pin a release when reproducibility matters:
 
 ```bash
-docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.1.0
+docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.0
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:1.1.0
+  ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.0
 ```
 
 ## MCP Client Config

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,13 @@ tags:
 
 `cloakbrowser-mcp` is a Model Context Protocol browser automation server that runs upstream `@playwright/mcp` with the CloakBrowser Chromium binary. Use it when you want Playwright MCP-compatible browser tools, CloakBrowser execution, npm installation, or a Docker image for stdio and Streamable HTTP MCP clients.
 
-Current version: <!-- project-version -->v1.1.0<!-- /project-version -->.
+Current version: <!-- project-version -->v1.2.0<!-- /project-version -->.
 
 ## Version Compatibility
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base                 | CloakBrowser | Transport              | Parity         |
 | ---------------- | --------------- | ------------------------------------------ | ------------ | ---------------------- | -------------- |
+| `1.2.0`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.1.0`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.0.2`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio                  | Compared in CI |
 | `1.0.1`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio                  | Compared in CI |

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,5 @@
 ---
-description: Release process for the CloakBrowser MCP npm package, Docker image, documentation site, and GitHub Pages deployment.
+description: Release process for the CloakBrowser MCP npm package, Docker image, documentation site, MCP Registry listing, and GitHub Pages deployment.
 icon: material/tag-check
 tags:
   - Project Internals
@@ -27,10 +27,12 @@ Configure these settings before the first release.
 | Branch protection | Require `Actionlint`, `CI`, `CodeQL`, and `Dependency Review` before merging to `main`. |
 | Pages | Set `Build and deployment -> Source` to `GitHub Actions`. |
 | Packages | Allow GitHub Actions to publish packages to GitHub Packages. |
-| Environments | Create `npm-production` and `docker-production`. |
+| Environments | Create `npm-production`, `docker-production`, and `mcp-registry-production`. |
 | Code scanning | Enable code scanning to view CodeQL, Scorecard, and Trivy SARIF results. |
 
-Add required reviewers to `npm-production` and `docker-production` if releases should require manual approval after a GitHub Release is published.
+Add required reviewers to `npm-production`, `docker-production`, and
+`mcp-registry-production` if releases should require manual approval after a
+GitHub Release is published.
 
 ## npm Publishing
 
@@ -110,6 +112,45 @@ repository.
 Docker multi-platform publishing is intentionally limited to `linux/amd64`
 until CloakBrowser and upstream Playwright MCP behavior are verified on other
 architectures.
+
+## MCP Registry Publishing
+
+The MCP Registry release workflow publishes `server.json` to the official
+registry at:
+
+```text
+https://registry.modelcontextprotocol.io
+```
+
+Server publishing uses the official `mcp-publisher` CLI and GitHub Actions OIDC.
+Do not open a pull request to `modelcontextprotocol/registry` to list this
+server; that repository explicitly requires package authors to publish with
+`mcp-publisher`.
+
+The workflow does not need Glama, billing, a GitHub PAT, DNS credentials, or
+long-lived registry secrets. It uses:
+
+- `id-token: write` for GitHub OIDC authentication;
+- `mcp-publisher login github-oidc`;
+- the existing GitHub namespace `io.github.swimmwatch/cloakbrowser-mcp`;
+- the npm package `mcpName` value to prove npm package ownership;
+- the Docker image label `io.modelcontextprotocol.server.name` to prove OCI
+  image ownership.
+
+The MCP Registry workflow starts from the same GitHub Release event as npm,
+Docker, and documentation publishing. Before publishing, it waits for the
+matching npm package and GHCR image tag to become visible, validates
+`server.json` locally, validates it against the official registry, and then
+publishes the server metadata.
+
+Manual re-publishing is available from GitHub Actions by running
+`MCP Registry Release` with a release tag such as `v1.2.0`.
+
+Verify the published registry entry with:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.swimmwatch/cloakbrowser-mcp"
+```
 
 ## Security Workflows
 
@@ -192,7 +233,8 @@ Before publishing a release:
 - Mark the release as prerelease when publishing a `next` npm version.
 - Confirm the npm Trusted Publisher is configured for `npm-release.yml` and
   `npm-production`.
-- Confirm `npm-production` and `docker-production` environments exist.
+- Confirm `npm-production`, `docker-production`, and `mcp-registry-production`
+  environments exist.
 - Confirm GitHub code scanning is enabled if SARIF upload visibility is needed.
 - Confirm GHCR package visibility is public after the first Docker publish.
 

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -13,6 +13,7 @@ Playwright MCP version it is built and tested against.
 
 | cloakbrowser-mcp | @playwright/mcp dependency | Playwright MCP Docker base | CloakBrowser dependency | Node.js | Transport | Tested platform | Tool parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.1.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.0.2` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.0.1` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser-mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Playwright MCP bridge that runs upstream browser tools with CloakBrowser.",
   "mcpName": "io.github.swimmwatch/cloakbrowser-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.swimmwatch/cloakbrowser-mcp",
   "title": "CloakBrowser MCP",
   "description": "Playwright MCP bridge that runs upstream browser tools with the CloakBrowser Chromium binary.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "websiteUrl": "https://swimmwatch.github.io/cloakbrowser-mcp/",
   "repository": {
     "url": "https://github.com/swimmwatch/cloakbrowser-mcp",
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "transport": {
         "type": "stdio"
       },
@@ -67,7 +67,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "packageArguments": [
         {
           "type": "named",
@@ -162,7 +162,7 @@
     {
       "registryType": "oci",
       "registryBaseUrl": "https://ghcr.io",
-      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.1.0",
+      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Adds official MCP Registry publishing for the `v1.2.0` release flow.

- adds a release workflow that publishes `server.json` with `mcp-publisher` and GitHub Actions OIDC
- updates package/server/docs metadata to `1.2.0`
- documents MCP Registry setup and verification
- updates version compatibility tables and changelog

## Validation

- [x] Scanned Keep a Changelog 1.1.0 before editing `CHANGELOG.md`
- [x] Scanned Conventional Commits 1.0.0 before committing
- [x] `npm run server:validate`
- [x] `mcp-publisher validate server.json`
- [x] `npm run docs:build`
- [x] `npm run docs:seo:validate`
- [x] `npm run format:check`
- [x] `npm run check`
- [x] actionlint
- [x] zizmor
