### PR TITLE
Fix MCP Registry OCI metadata

### DIFF
--- a/.github/workflows/mcp-registry-release.yml
+++ b/.github/workflows/mcp-registry-release.yml
@@ -31,8 +31,6 @@ jobs:
     environment: mcp-registry-production
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.release.tag_name || inputs.version_tag }}
 
       - uses: actions/setup-node@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-27
+
+### Fixed
+
+- Removed the OCI package `registryBaseUrl` from `server.json` so official MCP Registry publishing accepts the GHCR image metadata.
+- Added local validation for the official MCP Registry OCI metadata rule.
+
 ## [1.2.0] - 2026-05-27
 
 ### Added
@@ -72,7 +79,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generated configuration documentation based on the removed native config schema.
 - Public SEO setup guide and stale roadmap page from the published documentation.
 
-[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.0.1...v1.0.2

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The server is intentionally thin:
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base | CloakBrowser | Node.js | Transport | Platform | Parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.1` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.1.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.0.2` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 Pin a release when reproducibility matters:
 
 ```bash
-npx -y cloakbrowser-mcp@1.2.0
+npx -y cloakbrowser-mcp@1.2.1
 ```
 
 The npm package requires Node.js 20 or newer. CloakBrowser downloads its Chromium binary on first use unless it is already cached.
@@ -55,10 +55,10 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
 Pin a release when reproducibility matters:
 
 ```bash
-docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.0
+docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.1
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.0
+  ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.1
 ```
 
 ## MCP Client Config

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,13 @@ tags:
 
 `cloakbrowser-mcp` is a Model Context Protocol browser automation server that runs upstream `@playwright/mcp` with the CloakBrowser Chromium binary. Use it when you want Playwright MCP-compatible browser tools, CloakBrowser execution, npm installation, or a Docker image for stdio and Streamable HTTP MCP clients.
 
-Current version: <!-- project-version -->v1.2.0<!-- /project-version -->.
+Current version: <!-- project-version -->v1.2.1<!-- /project-version -->.
 
 ## Version Compatibility
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base                 | CloakBrowser | Transport              | Parity         |
 | ---------------- | --------------- | ------------------------------------------ | ------------ | ---------------------- | -------------- |
+| `1.2.1`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.0`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.1.0`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.0.2`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio                  | Compared in CI |

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -13,6 +13,7 @@ Playwright MCP version it is built and tested against.
 
 | cloakbrowser-mcp | @playwright/mcp dependency | Playwright MCP Docker base | CloakBrowser dependency | Node.js | Transport | Tested platform | Tool parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.1` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.1.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.0.2` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Playwright MCP bridge that runs upstream browser tools with CloakBrowser.",
   "mcpName": "io.github.swimmwatch/cloakbrowser-mcp",
   "type": "module",

--- a/scripts/validate-server-json.mjs
+++ b/scripts/validate-server-json.mjs
@@ -13,6 +13,14 @@ if (typeof schemaUrl !== 'string' || schemaUrl.length === 0) {
   throw new Error(`${serverJsonPath} must declare a non-empty $schema URL.`);
 }
 
+for (const [index, pkg] of (serverJson.packages ?? []).entries()) {
+  if (pkg?.registryType === 'oci' && Object.hasOwn(pkg, 'registryBaseUrl')) {
+    throw new Error(
+      `${serverJsonPath} package ${index + 1} is an OCI package and must not declare registryBaseUrl; use the canonical image reference in identifier instead.`,
+    );
+  }
+}
+
 const schema = await fetchJson(schemaUrl, {
   userAgent: 'cloakbrowser-mcp-server-validator',
 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.swimmwatch/cloakbrowser-mcp",
   "title": "CloakBrowser MCP",
   "description": "Playwright MCP bridge that runs upstream browser tools with the CloakBrowser Chromium binary.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "websiteUrl": "https://swimmwatch.github.io/cloakbrowser-mcp/",
   "repository": {
     "url": "https://github.com/swimmwatch/cloakbrowser-mcp",
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "transport": {
         "type": "stdio"
       },
@@ -67,7 +67,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "packageArguments": [
         {
           "type": "named",
@@ -161,8 +161,7 @@
     },
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
-      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.0",
+      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Fixes the MCP Registry publish blocker found during the v1.2.0 release.

- removes `registryBaseUrl` from the OCI package entry in `server.json`
- adds local validation for the official registry OCI metadata rule
- updates release metadata and documentation to v1.2.1
- lets manual MCP Registry workflow dispatch use the workflow branch while applying the requested release tag

## Validation

- [x] `npm run server:validate`
- [x] `mcp-publisher validate server.json`
- [x] `npm run docs:build`
- [x] `npm run docs:seo:validate`
- [x] `npm run check`
- [x] actionlint
- [x] zizmor
