### PR TITLE
Fix MCP Registry release verification

### DIFF
--- a/.github/workflows/mcp-registry-release.yml
+++ b/.github/workflows/mcp-registry-release.yml
@@ -90,10 +90,28 @@ jobs:
       - name: Validate server metadata with mcp-publisher
         run: ./mcp-publisher validate server.json
 
+      - id: registry-entry
+        name: Check existing registry entry
+        env:
+          SERVER_NAME: ${{ env.MCP_REGISTRY_SERVER_NAME }}
+          SERVER_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          response="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}")"
+          echo "$response" | jq '{metadata, servers: [.servers[] | {name: .server.name, version: .server.version}]}'
+          count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[] | select(.server.name == $name and .server.version == $version)] | length')"
+          if [ "$count" = "1" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Authenticate to MCP Registry
+        if: steps.registry-entry.outputs.exists != 'true'
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
+        if: steps.registry-entry.outputs.exists != 'true'
         run: ./mcp-publisher publish server.json
 
       - name: Verify registry entry
@@ -104,8 +122,8 @@ jobs:
           set -euo pipefail
           for attempt in $(seq 1 20); do
             response="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}")"
-            echo "$response" | jq .
-            count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[] | select(.name == $name and .version == $version)] | length')"
+            echo "$response" | jq '{metadata, servers: [.servers[] | {name: .server.name, version: .server.version}]}'
+            count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[] | select(.server.name == $name and .server.version == $version)] | length')"
             if [ "$count" = "1" ]; then
               echo "$SERVER_NAME version $SERVER_VERSION is visible in the MCP Registry"
               exit 0


### PR DESCRIPTION
## Summary

Fixes the MCP Registry release verification step after the v1.2.1 publish succeeded but the workflow checked the wrong API response shape.

- checks `.servers[].server.name` and `.servers[].server.version`
- keeps the verification log compact
- skips publish during manual reruns when the server version is already visible in the registry

## Validation

- [x] `npm run format:check`
- [x] `npm run server:validate`
- [x] actionlint
- [x] zizmor
