### PR TITLE
Prepare v1.2.3 MCP Registry publish action

### DIFF
--- a/.github/actions/mcp-registry-publish/action.yml
+++ b/.github/actions/mcp-registry-publish/action.yml
@@ -1,0 +1,294 @@
+name: MCP Registry Publish
+description: Validate and publish an MCP server to the official MCP Registry.
+
+inputs:
+  server-json:
+    description: Path to the MCP server metadata file.
+    required: false
+    default: server.json
+  server-name:
+    description: Official MCP server name to publish and verify.
+    required: true
+  server-version:
+    description: MCP server version to verify in the registry.
+    required: true
+  npm-package:
+    description: npm package name that must be visible before publishing.
+    required: true
+  npm-version:
+    description: npm package version that must be visible before publishing.
+    required: true
+  docker-image:
+    description: OCI image name that must be visible before publishing.
+    required: true
+  docker-tag:
+    description: OCI image tag that must be visible before publishing.
+    required: true
+  registry-api-url:
+    description: MCP Registry API base URL.
+    required: false
+    default: https://registry.modelcontextprotocol.io/v0.1
+  publisher-version:
+    description: mcp-publisher release tag to install, or latest.
+    required: false
+    default: latest
+  npm-wait-attempts:
+    description: Number of npm availability checks before failing.
+    required: false
+    default: '120'
+  npm-wait-interval-seconds:
+    description: Seconds to wait between npm availability checks.
+    required: false
+    default: '30'
+  docker-wait-attempts:
+    description: Number of Docker availability checks before failing.
+    required: false
+    default: '120'
+  docker-wait-interval-seconds:
+    description: Seconds to wait between Docker availability checks.
+    required: false
+    default: '30'
+  registry-wait-attempts:
+    description: Number of registry verification checks before failing.
+    required: false
+    default: '20'
+  registry-wait-interval-seconds:
+    description: Seconds to wait between registry verification checks.
+    required: false
+    default: '15'
+  skip-existing:
+    description: Skip publish when the same server version already exists.
+    required: false
+    default: 'true'
+  validation-command:
+    description: Local validation command to run before mcp-publisher validate.
+    required: false
+    default: npm run server:validate
+
+outputs:
+  published:
+    description: Whether this action ran mcp-publisher publish.
+    value: ${{ steps.result.outputs.published }}
+  existing:
+    description: Whether the target server version already existed before publish.
+    value: ${{ steps.registry-entry.outputs.exists }}
+  server-version:
+    description: Published or verified server version.
+    value: ${{ steps.result.outputs.server-version }}
+  registry-url:
+    description: Registry search URL used for verification.
+    value: ${{ steps.registry-url.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - id: validate-inputs
+      name: Validate inputs
+      shell: bash
+      env:
+        NPM_WAIT_ATTEMPTS: ${{ inputs.npm-wait-attempts }}
+        NPM_WAIT_INTERVAL_SECONDS: ${{ inputs.npm-wait-interval-seconds }}
+        DOCKER_WAIT_ATTEMPTS: ${{ inputs.docker-wait-attempts }}
+        DOCKER_WAIT_INTERVAL_SECONDS: ${{ inputs.docker-wait-interval-seconds }}
+        REGISTRY_WAIT_ATTEMPTS: ${{ inputs.registry-wait-attempts }}
+        REGISTRY_WAIT_INTERVAL_SECONDS: ${{ inputs.registry-wait-interval-seconds }}
+        SKIP_EXISTING: ${{ inputs.skip-existing }}
+      run: |
+        set -euo pipefail
+
+        for name in \
+          NPM_WAIT_ATTEMPTS \
+          NPM_WAIT_INTERVAL_SECONDS \
+          DOCKER_WAIT_ATTEMPTS \
+          DOCKER_WAIT_INTERVAL_SECONDS \
+          REGISTRY_WAIT_ATTEMPTS \
+          REGISTRY_WAIT_INTERVAL_SECONDS
+        do
+          value="${!name}"
+          if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error title=Invalid action input::$name must be a positive integer"
+            exit 1
+          fi
+        done
+
+        case "$SKIP_EXISTING" in
+          true|false) ;;
+          *)
+            echo "::error title=Invalid action input::skip-existing must be true or false"
+            exit 1
+            ;;
+        esac
+
+    - id: registry-url
+      name: Build registry query URL
+      shell: bash
+      env:
+        REGISTRY_API_URL: ${{ inputs.registry-api-url }}
+        SERVER_NAME: ${{ inputs.server-name }}
+      run: |
+        set -euo pipefail
+        encoded_name="$(jq -nr --arg value "$SERVER_NAME" '$value | @uri')"
+        echo "url=${REGISTRY_API_URL%/}/servers?search=${encoded_name}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for npm package
+      shell: bash
+      env:
+        PACKAGE_NAME: ${{ inputs.npm-package }}
+        PACKAGE_VERSION: ${{ inputs.npm-version }}
+        WAIT_ATTEMPTS: ${{ inputs.npm-wait-attempts }}
+        WAIT_INTERVAL_SECONDS: ${{ inputs.npm-wait-interval-seconds }}
+      run: |
+        set -euo pipefail
+        package="${PACKAGE_NAME}@${PACKAGE_VERSION}"
+        for attempt in $(seq 1 "$WAIT_ATTEMPTS"); do
+          if npm view "$package" version >/dev/null 2>&1; then
+            echo "$package is available on npm"
+            exit 0
+          fi
+          echo "Waiting for $package on npm ($attempt/$WAIT_ATTEMPTS)"
+          sleep "$WAIT_INTERVAL_SECONDS"
+        done
+        echo "::error title=npm package not available::$package was not visible after waiting"
+        exit 1
+
+    - name: Wait for Docker image
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.docker-image }}:${{ inputs.docker-tag }}
+        WAIT_ATTEMPTS: ${{ inputs.docker-wait-attempts }}
+        WAIT_INTERVAL_SECONDS: ${{ inputs.docker-wait-interval-seconds }}
+      run: |
+        set -euo pipefail
+        for attempt in $(seq 1 "$WAIT_ATTEMPTS"); do
+          if docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
+            echo "$IMAGE_REF is available"
+            exit 0
+          fi
+          echo "Waiting for $IMAGE_REF ($attempt/$WAIT_ATTEMPTS)"
+          sleep "$WAIT_INTERVAL_SECONDS"
+        done
+        echo "::error title=Docker image not available::$IMAGE_REF was not visible after waiting"
+        exit 1
+
+    - name: Run local server metadata validation
+      shell: bash
+      env:
+        VALIDATION_COMMAND: ${{ inputs.validation-command }}
+      run: |
+        set -euo pipefail
+        bash -euo pipefail -c "$VALIDATION_COMMAND"
+
+    - id: publisher
+      name: Install mcp-publisher
+      shell: bash
+      env:
+        PUBLISHER_VERSION: ${{ inputs.publisher-version }}
+      run: |
+        set -euo pipefail
+        case "$PUBLISHER_VERSION" in
+          latest) release_path="latest/download" ;;
+          v*) release_path="download/$PUBLISHER_VERSION" ;;
+          *) release_path="download/v$PUBLISHER_VERSION" ;;
+        esac
+
+        os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+        publisher_dir="$RUNNER_TEMP/mcp-publisher"
+        publisher_path="$publisher_dir/mcp-publisher"
+        archive="$RUNNER_TEMP/mcp-publisher.tar.gz"
+        url="https://github.com/modelcontextprotocol/registry/releases/${release_path}/mcp-publisher_${os}_${arch}.tar.gz"
+
+        mkdir -p "$publisher_dir"
+        curl -fsSL "$url" -o "$archive"
+        tar -xzf "$archive" -C "$publisher_dir" mcp-publisher
+        chmod +x "$publisher_path"
+        echo "path=$publisher_path" >> "$GITHUB_OUTPUT"
+
+    - name: Validate server metadata with mcp-publisher
+      shell: bash
+      env:
+        PUBLISHER: ${{ steps.publisher.outputs.path }}
+        SERVER_JSON: ${{ inputs.server-json }}
+      run: |
+        set -euo pipefail
+        "$PUBLISHER" validate "$SERVER_JSON"
+
+    - id: registry-entry
+      name: Check existing registry entry
+      shell: bash
+      env:
+        REGISTRY_URL: ${{ steps.registry-url.outputs.url }}
+        SERVER_NAME: ${{ inputs.server-name }}
+        SERVER_VERSION: ${{ inputs.server-version }}
+      run: |
+        set -euo pipefail
+        response="$(curl -fsSL "$REGISTRY_URL")"
+        echo "$response" | jq '{metadata, servers: [.servers[]? | {name: .server.name, version: .server.version}]}'
+        count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[]? | select(.server.name == $name and .server.version == $version)] | length')"
+        if [ "$count" = "1" ]; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Authenticate to MCP Registry
+      if: ${{ inputs.skip-existing != 'true' || steps.registry-entry.outputs.exists != 'true' }}
+      shell: bash
+      env:
+        PUBLISHER: ${{ steps.publisher.outputs.path }}
+      run: |
+        set -euo pipefail
+        "$PUBLISHER" login github-oidc
+
+    - id: publish
+      name: Publish to MCP Registry
+      if: ${{ inputs.skip-existing != 'true' || steps.registry-entry.outputs.exists != 'true' }}
+      shell: bash
+      env:
+        PUBLISHER: ${{ steps.publisher.outputs.path }}
+        SERVER_JSON: ${{ inputs.server-json }}
+      run: |
+        set -euo pipefail
+        "$PUBLISHER" publish "$SERVER_JSON"
+        echo "published=true" >> "$GITHUB_OUTPUT"
+
+    - name: Verify registry entry
+      shell: bash
+      env:
+        REGISTRY_URL: ${{ steps.registry-url.outputs.url }}
+        SERVER_NAME: ${{ inputs.server-name }}
+        SERVER_VERSION: ${{ inputs.server-version }}
+        WAIT_ATTEMPTS: ${{ inputs.registry-wait-attempts }}
+        WAIT_INTERVAL_SECONDS: ${{ inputs.registry-wait-interval-seconds }}
+      run: |
+        set -euo pipefail
+        for attempt in $(seq 1 "$WAIT_ATTEMPTS"); do
+          response="$(curl -fsSL "$REGISTRY_URL")"
+          echo "$response" | jq '{metadata, servers: [.servers[]? | {name: .server.name, version: .server.version}]}'
+          count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[]? | select(.server.name == $name and .server.version == $version)] | length')"
+          if [ "$count" = "1" ]; then
+            echo "$SERVER_NAME version $SERVER_VERSION is visible in the MCP Registry"
+            exit 0
+          fi
+          echo "Waiting for $SERVER_NAME version $SERVER_VERSION in the MCP Registry ($attempt/$WAIT_ATTEMPTS)"
+          sleep "$WAIT_INTERVAL_SECONDS"
+        done
+        echo "::error title=MCP Registry verification failed::Could not find $SERVER_NAME version $SERVER_VERSION"
+        exit 1
+
+    - id: result
+      name: Set action outputs
+      shell: bash
+      env:
+        EXISTING: ${{ steps.registry-entry.outputs.exists }}
+        PUBLISHED: ${{ steps.publish.outputs.published }}
+        SERVER_VERSION: ${{ inputs.server-version }}
+      run: |
+        set -euo pipefail
+        echo "existing=$EXISTING" >> "$GITHUB_OUTPUT"
+        echo "server-version=$SERVER_VERSION" >> "$GITHUB_OUTPUT"
+        if [ "$PUBLISHED" = "true" ]; then
+          echo "published=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "published=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/mcp-registry-release.yml
+++ b/.github/workflows/mcp-registry-release.yml
@@ -23,6 +23,7 @@ env:
   MCP_REGISTRY_SERVER_NAME: io.github.swimmwatch/cloakbrowser-mcp
   MCP_REGISTRY_PACKAGE_NAME: cloakbrowser-mcp
   MCP_REGISTRY_IMAGE_NAME: ghcr.io/swimmwatch/cloakbrowser-mcp
+  MCP_REGISTRY_API_URL: https://registry.modelcontextprotocol.io/v0.1
 
 jobs:
   publish:
@@ -45,91 +46,17 @@ jobs:
           RELEASE_VERSION_TAG: ${{ github.event.release.tag_name || inputs.version_tag }}
         run: npm run version:apply -- "$RELEASE_VERSION_TAG"
 
-      - name: Wait for npm package
-        env:
-          PACKAGE_NAME: ${{ env.MCP_REGISTRY_PACKAGE_NAME }}
-          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          package="${PACKAGE_NAME}@${PACKAGE_VERSION}"
-          for attempt in $(seq 1 120); do
-            if npm view "$package" version >/dev/null 2>&1; then
-              echo "$package is available on npm"
-              exit 0
-            fi
-            echo "Waiting for $package on npm ($attempt/120)"
-            sleep 30
-          done
-          echo "::error title=npm package not available::$package was not visible after waiting"
-          exit 1
-
-      - name: Wait for Docker image
-        env:
-          IMAGE_REF: ${{ env.MCP_REGISTRY_IMAGE_NAME }}:${{ steps.release.outputs.docker_version }}
-        run: |
-          set -euo pipefail
-          for attempt in $(seq 1 120); do
-            if docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
-              echo "$IMAGE_REF is available in GHCR"
-              exit 0
-            fi
-            echo "Waiting for $IMAGE_REF in GHCR ($attempt/120)"
-            sleep 30
-          done
-          echo "::error title=Docker image not available::$IMAGE_REF was not visible after waiting"
-          exit 1
-
-      - run: npm run server:validate
-
-      - name: Install mcp-publisher
-        run: |
-          set -euo pipefail
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
-          chmod +x mcp-publisher
-
-      - name: Validate server metadata with mcp-publisher
-        run: ./mcp-publisher validate server.json
-
-      - id: registry-entry
-        name: Check existing registry entry
-        env:
-          SERVER_NAME: ${{ env.MCP_REGISTRY_SERVER_NAME }}
-          SERVER_VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          response="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}")"
-          echo "$response" | jq '{metadata, servers: [.servers[] | {name: .server.name, version: .server.version}]}'
-          count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[] | select(.server.name == $name and .server.version == $version)] | length')"
-          if [ "$count" = "1" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Authenticate to MCP Registry
-        if: steps.registry-entry.outputs.exists != 'true'
-        run: ./mcp-publisher login github-oidc
-
-      - name: Publish to MCP Registry
-        if: steps.registry-entry.outputs.exists != 'true'
-        run: ./mcp-publisher publish server.json
-
-      - name: Verify registry entry
-        env:
-          SERVER_NAME: ${{ env.MCP_REGISTRY_SERVER_NAME }}
-          SERVER_VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          for attempt in $(seq 1 20); do
-            response="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}")"
-            echo "$response" | jq '{metadata, servers: [.servers[] | {name: .server.name, version: .server.version}]}'
-            count="$(echo "$response" | jq --arg name "$SERVER_NAME" --arg version "$SERVER_VERSION" '[.servers[] | select(.server.name == $name and .server.version == $version)] | length')"
-            if [ "$count" = "1" ]; then
-              echo "$SERVER_NAME version $SERVER_VERSION is visible in the MCP Registry"
-              exit 0
-            fi
-            echo "Waiting for $SERVER_NAME version $SERVER_VERSION in the MCP Registry ($attempt/20)"
-            sleep 15
-          done
-          echo "::error title=MCP Registry verification failed::Could not find $SERVER_NAME version $SERVER_VERSION"
-          exit 1
+      - id: mcp-registry-publish
+        name: Publish to MCP Registry
+        uses: ./.github/actions/mcp-registry-publish
+        with:
+          server-json: server.json
+          server-name: ${{ env.MCP_REGISTRY_SERVER_NAME }}
+          server-version: ${{ steps.release.outputs.version }}
+          npm-package: ${{ env.MCP_REGISTRY_PACKAGE_NAME }}
+          npm-version: ${{ steps.release.outputs.version }}
+          docker-image: ${{ env.MCP_REGISTRY_IMAGE_NAME }}
+          docker-tag: ${{ steps.release.outputs.docker_version }}
+          registry-api-url: ${{ env.MCP_REGISTRY_API_URL }}
+          publisher-version: latest
+          skip-existing: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-05-27
+
+### Changed
+
+- Refactored MCP Registry release publishing into a local `MCP Registry Publish` composite GitHub Action.
+- Added a dedicated README badge for the official MCP Registry listing.
+
 ## [1.2.2] - 2026-05-27
 
 ### Fixed
@@ -86,7 +93,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generated configuration documentation based on the removed native config schema.
 - Public SEO setup guide and stale roadmap page from the published documentation.
 
-[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.2...HEAD
+[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.1.0...v1.2.0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Docker Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docker-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docker-release.yml)
 [![Docs Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docs-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/docs-release.yml)
 [![MCP Registry Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/mcp-registry-release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/mcp-registry-release.yml)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-published-2E8555)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.swimmwatch%2Fcloakbrowser-mcp)
 [![npm](https://img.shields.io/npm/v/cloakbrowser-mcp.svg?logo=npm)](https://www.npmjs.com/package/cloakbrowser-mcp)
 [![Node.js >=20](https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![MCP Server](https://img.shields.io/badge/MCP-server-000000)](https://modelcontextprotocol.io/)
@@ -36,6 +37,7 @@ The server is intentionally thin:
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base | CloakBrowser | Node.js | Transport | Platform | Parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.3` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.2` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.1` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 Pin a release when reproducibility matters:
 
 ```bash
-npx -y cloakbrowser-mcp@1.2.2
+npx -y cloakbrowser-mcp@1.2.3
 ```
 
 The npm package requires Node.js 20 or newer. CloakBrowser downloads its Chromium binary on first use unless it is already cached.
@@ -55,10 +55,10 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
 Pin a release when reproducibility matters:
 
 ```bash
-docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.2
+docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.3
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.2
+  ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.3
 ```
 
 ## MCP Client Config

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,13 @@ tags:
 
 `cloakbrowser-mcp` is a Model Context Protocol browser automation server that runs upstream `@playwright/mcp` with the CloakBrowser Chromium binary. Use it when you want Playwright MCP-compatible browser tools, CloakBrowser execution, npm installation, or a Docker image for stdio and Streamable HTTP MCP clients.
 
-Current version: <!-- project-version -->v1.2.2<!-- /project-version -->.
+Current version: <!-- project-version -->v1.2.3<!-- /project-version -->.
 
 ## Version Compatibility
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base                 | CloakBrowser | Transport              | Parity         |
 | ---------------- | --------------- | ------------------------------------------ | ------------ | ---------------------- | -------------- |
+| `1.2.3`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.2`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.1`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.0`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |

--- a/docs/release.md
+++ b/docs/release.md
@@ -122,10 +122,10 @@ registry at:
 https://registry.modelcontextprotocol.io
 ```
 
-Server publishing uses the official `mcp-publisher` CLI and GitHub Actions OIDC.
-Do not open a pull request to `modelcontextprotocol/registry` to list this
-server; that repository explicitly requires package authors to publish with
-`mcp-publisher`.
+Server publishing uses the local `MCP Registry Publish` composite GitHub Action,
+the official `mcp-publisher` CLI, and GitHub Actions OIDC. Do not open a pull
+request to `modelcontextprotocol/registry` to list this server; that repository
+explicitly requires package authors to publish with `mcp-publisher`.
 
 The workflow does not need Glama, billing, a GitHub PAT, DNS credentials, or
 long-lived registry secrets. It uses:
@@ -138,13 +138,13 @@ long-lived registry secrets. It uses:
   image ownership.
 
 The MCP Registry workflow starts from the same GitHub Release event as npm,
-Docker, and documentation publishing. Before publishing, it waits for the
-matching npm package and GHCR image tag to become visible, validates
-`server.json` locally, validates it against the official registry, and then
-publishes the server metadata.
+Docker, and documentation publishing. Before publishing, the composite action
+waits for the matching npm package and GHCR image tag to become visible,
+validates `server.json` locally, validates it against the official registry,
+and then publishes the server metadata.
 
 Manual re-publishing is available from GitHub Actions by running
-`MCP Registry Release` with a release tag such as `v1.2.0`.
+`MCP Registry Release` with a release tag such as `v1.2.3`.
 
 Verify the published registry entry with:
 

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -13,6 +13,7 @@ Playwright MCP version it is built and tested against.
 
 | cloakbrowser-mcp | @playwright/mcp dependency | Playwright MCP Docker base | CloakBrowser dependency | Node.js | Transport | Tested platform | Tool parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.3` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.2` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.1` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser-mcp",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Playwright MCP bridge that runs upstream browser tools with CloakBrowser.",
   "mcpName": "io.github.swimmwatch/cloakbrowser-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.swimmwatch/cloakbrowser-mcp",
   "title": "CloakBrowser MCP",
   "description": "Playwright MCP bridge that runs upstream browser tools with the CloakBrowser Chromium binary.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "websiteUrl": "https://swimmwatch.github.io/cloakbrowser-mcp/",
   "repository": {
     "url": "https://github.com/swimmwatch/cloakbrowser-mcp",
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "transport": {
         "type": "stdio"
       },
@@ -67,7 +67,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "packageArguments": [
         {
           "type": "named",
@@ -161,7 +161,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.2",
+      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Prepares v1.2.3 as an infrastructure-only patch release.

This PR extracts MCP Registry publishing into a local composite GitHub Action named `MCP Registry Publish`, keeps the release workflow as the orchestrator, and adds a dedicated README badge for the official MCP Registry listing.

## Changes

- Adds `.github/actions/mcp-registry-publish/action.yml` with parameterized inputs, outputs, artifact waits, local validation, `mcp-publisher` validation, OIDC login, publish, and registry verification.
- Refactors `mcp-registry-release.yml` to call the local action with explicit inputs.
- Updates release metadata, compatibility tables, pinned examples, and changelog for v1.2.3.

## Validation

- [x] Scanned Keep a Changelog 1.1.0.
- [x] Scanned Conventional Commits 1.0.0.
- [x] `npm run server:validate`
- [x] latest `mcp-publisher validate server.json`
- [x] `npm run docs:build && npm run docs:seo:validate`
- [x] `npm run format:check`
- [x] `npm run check`
- [x] actionlint
- [x] zizmor high-severity scan
