### PR TITLE
Refresh MCP Registry auth during publish retries

### DIFF
--- a/.github/actions/mcp-registry-publish/action.yml
+++ b/.github/actions/mcp-registry-publish/action.yml
@@ -243,15 +243,6 @@ runs:
           echo "exists=false" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Authenticate to MCP Registry
-      if: ${{ inputs.skip-existing != 'true' || steps.registry-entry.outputs.exists != 'true' }}
-      shell: bash
-      env:
-        PUBLISHER: ${{ steps.publisher.outputs.path }}
-      run: |
-        set -euo pipefail
-        "$PUBLISHER" login github-oidc
-
     - id: publish
       name: Publish to MCP Registry
       if: ${{ inputs.skip-existing != 'true' || steps.registry-entry.outputs.exists != 'true' }}
@@ -277,6 +268,16 @@ runs:
         }
 
         for attempt in $(seq 1 "$PUBLISH_ATTEMPTS"); do
+          if ! "$PUBLISHER" login github-oidc; then
+            if [ "$attempt" = "$PUBLISH_ATTEMPTS" ]; then
+              echo "::error title=MCP Registry authentication failed::mcp-publisher login failed on the final attempt"
+              exit 1
+            fi
+            echo "mcp-publisher login failed; retrying in $PUBLISH_RETRY_INTERVAL_SECONDS seconds ($attempt/$PUBLISH_ATTEMPTS)"
+            sleep "$PUBLISH_RETRY_INTERVAL_SECONDS"
+            continue
+          fi
+
           if "$PUBLISHER" publish "$SERVER_JSON"; then
             echo "published=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Added retries around MCP Registry publishing to tolerate transient registry gateway timeouts.
+- Added retries with fresh GitHub OIDC login attempts around MCP Registry publishing to tolerate transient registry gateway timeouts.
 
 ## [1.2.3] - 2026-05-27
 


### PR DESCRIPTION
## Summary

Refreshes MCP Registry authentication before each publish retry.

The previous retry change handled registry `504` responses, but logs showed the registry JWT can expire before later retry attempts. This moves `mcp-publisher login github-oidc` into the retry loop so every publish attempt starts with a fresh OIDC-backed registry login.

## Validation

- [x] `npm run format:check`
- [x] actionlint
- [x] zizmor high-severity scan
