### PR TITLE
Add Glama release checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Replaced the separate npm, Docker, documentation, and MCP Registry release workflows with one unified `Release` workflow.
 - Simplified the local `MCP Registry Publish` composite action so npm and Docker publication ordering is handled by workflow job dependencies.
+- Added Glama ownership metadata, score badge, and release checklist documentation before the stable `1.2.5` release.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Zizmor](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/zizmor.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/zizmor.yml)
 [![Release](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/release.yml/badge.svg)](https://github.com/swimmwatch/cloakbrowser-mcp/actions/workflows/release.yml)
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-published-2E8555)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.swimmwatch%2Fcloakbrowser-mcp)
+[![cloakbrowser-mcp MCP server](https://glama.ai/mcp/servers/swimmwatch/cloakbrowser-mcp/badges/score.svg)](https://glama.ai/mcp/servers/swimmwatch/cloakbrowser-mcp)
 [![npm](https://img.shields.io/npm/v/cloakbrowser-mcp.svg?logo=npm)](https://www.npmjs.com/package/cloakbrowser-mcp)
 [![Node.js >=20](https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![MCP Server](https://img.shields.io/badge/MCP-server-000000)](https://modelcontextprotocol.io/)

--- a/docs/release.md
+++ b/docs/release.md
@@ -157,6 +157,34 @@ Verify the published registry entry with:
 curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.swimmwatch/cloakbrowser-mcp"
 ```
 
+## Glama Directory Checklist
+
+Glama directory scoring is separate from GitHub releases and official MCP
+Registry publishing. The repository includes `glama.json` so the
+`swimmwatch` maintainer account can claim or confirm ownership in Glama.
+
+Before publishing a stable release, complete the free Glama checklist:
+
+- sync the server from the Glama MCP server admin interface after `glama.json`
+  is merged to `main`;
+- open
+  `https://glama.ai/mcp/servers/swimmwatch/cloakbrowser-mcp/admin/dockerfile`;
+- configure Glama to build this repository Dockerfile and start the existing
+  stdio entrypoint without extra secrets;
+- keep the runtime compatible with CloakBrowser defaults: `cloak` browser
+  engine, headless mode, stdout output, and `/data` artifact storage;
+- click Deploy and wait for the build test to pass;
+- create and publish a Glama release with the same version as the GitHub
+  release, for example `1.2.5`;
+- use the Glama "Try in Browser" feature once after release to seed initial
+  usage;
+- add related servers manually, at minimum the official Playwright MCP server,
+  and optionally closely related browser automation alternatives.
+
+Do not add a billing method or paid Glama hosting just to improve the directory
+score. If Glama requires billing for a required checklist item, treat that as a
+release blocker that needs an explicit maintainer decision.
+
 ## Security Workflows
 
 The repository uses free security tooling:
@@ -242,6 +270,8 @@ Before publishing a release:
   `mcp-registry-production` environments exist.
 - Confirm GitHub code scanning is enabled if SARIF upload visibility is needed.
 - Confirm GHCR package visibility is public after the first Docker publish.
+- Confirm the Glama server has been synced, tested through the Dockerfile admin
+  page, and released with the same stable version.
 
 `SUPPORT.md` is intentionally deferred until the project has a stable support
 policy beyond GitHub issues and security advisories.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["swimmwatch"]
+}


### PR DESCRIPTION
## Summary

- Adds root `glama.json` ownership metadata for Glama.
- Adds the Glama score badge to the README.
- Documents the free Glama pre-release checklist and updates the v1.2.5 changelog.

## Verification

- [x] jq . glama.json
- [x] npm run server:validate
- [x] latest mcp-publisher validate server.json
- [x] npm run docs:build
- [x] npm run docs:seo:validate
- [x] npm run format:check
- [x] npm run check
- [x] actionlint
- [x] zizmor --min-severity high

## Notes

No runtime behavior, MCP tool contracts, Docker runtime, npm packaging, or release workflow behavior changed. The Glama UI steps still need to be completed by a maintainer after merge.