### PR TITLE
ci: publish Docker image to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,15 @@ jobs:
           sbom: true
           provenance: mode=max
 
+      - name: Update Docker Hub overview
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          readme-filepath: ./docs/dockerhub-readme.md
+          short-description: CloakBrowser-backed Playwright MCP browser automation for AI agents
+
   docs-build:
     runs-on: ubuntu-latest
     needs: metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ env:
   NPM_CONFIG_FUND: 'false'
   NODE_IMAGE_TAG: 22-bookworm-slim
   DOCKER_REGISTRY: ghcr.io
+  DOCKERHUB_IMAGE: swimmwatch/cloakbrowser-mcp
   IMAGE_NAME: cloakbrowser-mcp
   IMAGE_TITLE: cloakbrowser-mcp
   IMAGE_DESCRIPTION: Playwright MCP bridge that runs upstream browser tools with CloakBrowser
@@ -259,16 +260,25 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
-      - uses: docker/login-action@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=raw,value=${{ needs.metadata.outputs.docker_tag }}
             type=raw,value=${{ needs.metadata.outputs.docker_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ junit.xml
 
 # Runtime artifacts and browser caches
 /artifacts/
+/.playwright-mcp/
 /.cloakbrowser/
 /.cloakbrowser-mcp/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 dist
 coverage
 artifacts
+.playwright-mcp
 node_modules
 *.md
 *.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added Docker Hub publication and MCP Registry metadata for
+  `docker.io/swimmwatch/cloakbrowser-mcp` alongside GHCR.
+
 ## [1.2.6] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added Docker Hub publication and MCP Registry metadata for
   `docker.io/swimmwatch/cloakbrowser-mcp` alongside GHCR.
+- Added automatic Docker Hub repository overview updates from a
+  Docker-specific README.
 
 ## [1.2.6] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.2.7] - 2026-06-04
+
 ### Added
 
 - Added Docker Hub publication and MCP Registry metadata for
   `docker.io/swimmwatch/cloakbrowser-mcp` alongside GHCR.
 - Added automatic Docker Hub repository overview updates from a
   Docker-specific README.
+- Added a Docker Hub pulls badge to the README.
 
 ## [1.2.6] - 2026-05-31
 
@@ -126,7 +129,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generated configuration documentation based on the removed native config schema.
 - Public SEO setup guide and stale roadmap page from the published documentation.
 
-[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.6...HEAD
+[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.7...HEAD
+[1.2.7]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.3...v1.2.5
 [1.2.3]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.2...v1.2.3

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-published-2E8555)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.swimmwatch%2Fcloakbrowser-mcp)
 [![cloakbrowser-mcp MCP server](https://glama.ai/mcp/servers/swimmwatch/cloakbrowser-mcp/badges/score.svg)](https://glama.ai/mcp/servers/swimmwatch/cloakbrowser-mcp)
 [![npm](https://img.shields.io/npm/v/cloakbrowser-mcp.svg?logo=npm)](https://www.npmjs.com/package/cloakbrowser-mcp)
+[![Docker Hub pulls](https://img.shields.io/docker/pulls/swimmwatch/cloakbrowser-mcp?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/swimmwatch/cloakbrowser-mcp)
 [![Node.js >=20](https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![MCP Server](https://img.shields.io/badge/MCP-server-000000)](https://modelcontextprotocol.io/)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](docs/docker.md)
@@ -35,6 +36,7 @@ The server is intentionally thin:
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base | CloakBrowser | Node.js | Transport | Platform | Parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.7` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.6` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.5` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.3` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |

--- a/README.md
+++ b/README.md
@@ -75,18 +75,19 @@ For the complete generated CLI flag reference, see the published [CLI Reference]
 ## Run from Docker
 
 ```bash
-docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:latest
+docker pull swimmwatch/cloakbrowser-mcp:latest
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:latest
+  swimmwatch/cloakbrowser-mcp:latest
 
 docker run --rm --init -p 127.0.0.1:3000:3000 \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:latest \
+  swimmwatch/cloakbrowser-mcp:latest \
   --transport streamable-http --http-host 0.0.0.0 --http-port 3000
 ```
 
 The Docker image is based on the pinned official Playwright MCP image, installs the bridge under `/opt/cloakbrowser-mcp`, and writes artifacts to `/data` by default.
+The same tags are also published to `ghcr.io/swimmwatch/cloakbrowser-mcp`.
 
 ## MCP client configuration
 
@@ -121,7 +122,7 @@ The Docker image is based on the pinned official Playwright MCP image, installs 
         "-i",
         "-v",
         "/tmp/cloakbrowser-artifacts:/data",
-        "ghcr.io/swimmwatch/cloakbrowser-mcp:latest"
+        "swimmwatch/cloakbrowser-mcp:latest"
       ]
     }
   }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -15,12 +15,14 @@ The published image is the recommended runtime for repeatable MCP usage.
 ```bash
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:latest
+  swimmwatch/cloakbrowser-mcp:latest
 ```
 
 Artifacts are written to `/data` in the container. Mount that path to keep screenshots, snapshots, downloads, and network output.
 
 `--init` is recommended because browser automation can create short-lived child processes. Docker's init process reaps those children cleanly.
+
+The same release tags are published to Docker Hub as `swimmwatch/cloakbrowser-mcp` and to GHCR as `ghcr.io/swimmwatch/cloakbrowser-mcp`.
 
 ## Streamable HTTP
 
@@ -29,7 +31,7 @@ For local Streamable HTTP usage, publish the container port on loopback:
 ```bash
 docker run --rm --init -p 127.0.0.1:3000:3000 \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:latest \
+  swimmwatch/cloakbrowser-mcp:latest \
   --transport streamable-http --http-host 0.0.0.0 --http-port 3000
 ```
 
@@ -69,7 +71,7 @@ See the generated [CLI Reference](generated/cli.md) for all HTTP transport flags
         "-i",
         "-v",
         "/tmp/cloakbrowser-artifacts:/data",
-        "ghcr.io/swimmwatch/cloakbrowser-mcp:latest"
+        "swimmwatch/cloakbrowser-mcp:latest"
       ]
     }
   }

--- a/docs/dockerhub-readme.md
+++ b/docs/dockerhub-readme.md
@@ -1,0 +1,63 @@
+# cloakbrowser-mcp
+
+CloakBrowser-backed Playwright MCP browser automation for AI agents.
+
+`cloakbrowser-mcp` runs upstream Playwright MCP browser tools with the
+CloakBrowser Chromium binary. The bridge keeps upstream Playwright MCP tools
+unchanged and adds only local CloakBrowser introspection tools.
+
+## Pull
+
+```bash
+docker pull swimmwatch/cloakbrowser-mcp:latest
+```
+
+## Run
+
+```bash
+docker run --rm --init swimmwatch/cloakbrowser-mcp:latest --help
+```
+
+For stdio MCP usage with persisted artifacts:
+
+```bash
+docker run --rm --init -i \
+  -v "$PWD/artifacts:/data" \
+  swimmwatch/cloakbrowser-mcp:latest
+```
+
+## MCP client config
+
+```json
+{
+  "mcpServers": {
+    "cloakbrowser": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "--init",
+        "-i",
+        "-v",
+        "/tmp/cloakbrowser-artifacts:/data",
+        "swimmwatch/cloakbrowser-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+## Alternative registry
+
+The same release tags are also published to GHCR:
+
+```bash
+docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:latest
+```
+
+## Links
+
+- GitHub: https://github.com/swimmwatch/cloakbrowser-mcp
+- Documentation: https://swimmwatch.github.io/cloakbrowser-mcp/
+- npm: https://www.npmjs.com/package/cloakbrowser-mcp
+- MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.swimmwatch%2Fcloakbrowser-mcp

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,30 +35,31 @@ See the generated [CLI Reference](generated/cli.md) for the full flag list and m
 ## Docker
 
 ```bash
-docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:latest
+docker pull swimmwatch/cloakbrowser-mcp:latest
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:latest
+  swimmwatch/cloakbrowser-mcp:latest
 ```
 
 Docker is the most reproducible runtime because the image is based on the pinned official Playwright MCP image and includes a prepared CloakBrowser browser cache.
+The same tags are also published to `ghcr.io/swimmwatch/cloakbrowser-mcp`.
 
 For local Streamable HTTP with Docker, publish the port on loopback and bind the server inside the container:
 
 ```bash
 docker run --rm --init -p 127.0.0.1:3000:3000 \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:latest \
+  swimmwatch/cloakbrowser-mcp:latest \
   --transport streamable-http --http-host 0.0.0.0 --http-port 3000
 ```
 
 Pin a release when reproducibility matters:
 
 ```bash
-docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.6
+docker pull swimmwatch/cloakbrowser-mcp:1.2.6
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.6
+  swimmwatch/cloakbrowser-mcp:1.2.6
 ```
 
 ## MCP Client Config
@@ -97,7 +98,7 @@ For Streamable HTTP clients, start the server separately and configure the clien
         "-i",
         "-v",
         "/tmp/cloakbrowser-artifacts:/data",
-        "ghcr.io/swimmwatch/cloakbrowser-mcp:latest"
+        "swimmwatch/cloakbrowser-mcp:latest"
       ]
     }
   }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 Pin a release when reproducibility matters:
 
 ```bash
-npx -y cloakbrowser-mcp@1.2.6
+npx -y cloakbrowser-mcp@1.2.7
 ```
 
 The npm package requires Node.js 20 or newer. CloakBrowser downloads its Chromium binary on first use unless it is already cached.
@@ -56,10 +56,10 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
 Pin a release when reproducibility matters:
 
 ```bash
-docker pull swimmwatch/cloakbrowser-mcp:1.2.6
+docker pull swimmwatch/cloakbrowser-mcp:1.2.7
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  swimmwatch/cloakbrowser-mcp:1.2.6
+  swimmwatch/cloakbrowser-mcp:1.2.7
 ```
 
 ## MCP Client Config

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,13 @@ tags:
 
 `cloakbrowser-mcp` is a Model Context Protocol browser automation server that runs upstream `@playwright/mcp` with the CloakBrowser Chromium binary. Use it when you want Playwright MCP-compatible browser tools, CloakBrowser execution, npm installation, or a Docker image for stdio and Streamable HTTP MCP clients.
 
-Current version: <!-- project-version -->v1.2.6<!-- /project-version -->.
+Current version: <!-- project-version -->v1.2.7<!-- /project-version -->.
 
 ## Version Compatibility
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base                 | CloakBrowser | Transport              | Parity         |
 | ---------------- | --------------- | ------------------------------------------ | ------------ | ---------------------- | -------------- |
+| `1.2.7`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.6`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.5`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.3`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,8 @@
 Documentation: https://swimmwatch.github.io/cloakbrowser-mcp/
 Repository: https://github.com/swimmwatch/cloakbrowser-mcp
 npm package: https://www.npmjs.com/package/cloakbrowser-mcp
-Docker image: https://github.com/swimmwatch/cloakbrowser-mcp/pkgs/container/cloakbrowser-mcp
+Docker Hub image: https://hub.docker.com/r/swimmwatch/cloakbrowser-mcp
+GHCR image: https://github.com/swimmwatch/cloakbrowser-mcp/pkgs/container/cloakbrowser-mcp
 
 ## Key Pages
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -82,6 +82,7 @@
           "sameAs": [
             config.repo_url,
             "https://www.npmjs.com/package/cloakbrowser-mcp",
+            "https://hub.docker.com/r/swimmwatch/cloakbrowser-mcp",
             "https://github.com/swimmwatch/cloakbrowser-mcp/pkgs/container/cloakbrowser-mcp",
             "https://github.com/microsoft/playwright-mcp",
             "https://github.com/CloakHQ/CloakBrowser",

--- a/docs/release.md
+++ b/docs/release.md
@@ -83,6 +83,11 @@ The `docker` job uses the repository `GITHUB_TOKEN` with
 `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in the `docker-production`
 environment or repository secrets.
 
+The workflow updates the Docker Hub repository overview after a successful
+image push. Docker Hub does not pull the root `README.md` automatically for
+this GitHub Actions release flow; the Docker Hub-specific overview is
+maintained in `docs/dockerhub-readme.md`.
+
 Before pushing the release image, the workflow:
 
 - applies the release version;

--- a/docs/release.md
+++ b/docs/release.md
@@ -75,10 +75,13 @@ Docker images are published to:
 
 ```text
 ghcr.io/swimmwatch/cloakbrowser-mcp
+docker.io/swimmwatch/cloakbrowser-mcp
 ```
 
 The `docker` job uses the repository `GITHUB_TOKEN` with
-`packages: write`. No extra Docker token is required for GHCR.
+`packages: write` for GHCR. Docker Hub publishing requires
+`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in the `docker-production`
+environment or repository secrets.
 
 Before pushing the release image, the workflow:
 
@@ -108,7 +111,7 @@ image scans. SARIF results are uploaded to GitHub code scanning when code
 scanning is enabled.
 
 After the first publish, confirm the GHCR package is public and linked to this
-repository.
+repository, and confirm the Docker Hub repository is public.
 
 Docker multi-platform publishing is intentionally limited to `linux/amd64`
 until CloakBrowser and upstream Playwright MCP behavior are verified on other
@@ -162,7 +165,7 @@ GitHub's `https://github.com/mcp` registry is a separate curated discovery
 surface. Publishing to the official MCP Registry is required, but it does not
 guarantee immediate visibility on GitHub's `/mcp` page. Treat `npm run
 registry:check` as a release verification tool for the official registry, npm,
-GHCR, and a best-effort GitHub MCP visibility probe. Use `npm run
+GHCR, Docker Hub, and a best-effort GitHub MCP visibility probe. Use `npm run
 registry:check:strict` only after GitHub MCP visibility should become a hard
 gate.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,7 +9,7 @@ tags:
 # Release
 
 Releases are driven by a published GitHub Release whose tag is a semver value
-prefixed with `v`, for example `v1.2.6`.
+prefixed with `v`, for example `v1.2.7`.
 
 The unified `Release` workflow resolves the tag once, then passes the derived `version`,
 `version_tag`, and Docker-safe image tag through npm packaging, Docker build
@@ -192,7 +192,7 @@ Before publishing a stable release, complete the free Glama checklist:
   engine, headless mode, stdout output, and `/data` artifact storage;
 - click Deploy and wait for the build test to pass;
 - create and publish a Glama release with the same version as the GitHub
-  release, for example `1.2.6`;
+  release, for example `1.2.7`;
 - use the Glama "Try in Browser" feature once after release to seed initial
   usage;
 - add related servers manually, at minimum the official Playwright MCP server,
@@ -279,7 +279,7 @@ npm run upstream:check
 Before publishing a release:
 
 - Merge only after `Actionlint` and `CI` are green.
-- Create a GitHub Release from a tag like `v1.2.6`.
+- Create a GitHub Release from a tag like `v1.2.7`.
 - Mark the release as prerelease when publishing a `next` npm version.
 - Confirm the npm Trusted Publisher is configured for `release.yml` and
   `npm-production`.

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -13,6 +13,7 @@ Playwright MCP version it is built and tested against.
 
 | cloakbrowser-mcp | @playwright/mcp dependency | Playwright MCP Docker base | CloakBrowser dependency | Node.js | Transport | Tested platform | Tool parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.2.7` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.6` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.5` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.3` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ site_dir: site
 hooks:
   - docs/hooks/generate_cli_docs.py
 exclude_docs: |
+  dockerhub-readme.md
   hooks/
   overrides/
   requirements.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser-mcp",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Playwright MCP-compatible browser automation bridge for CloakBrowser Chromium.",
   "mcpName": "io.github.swimmwatch/cloakbrowser-mcp",
   "type": "module",

--- a/scripts/check-github-mcp-registry.mjs
+++ b/scripts/check-github-mcp-registry.mjs
@@ -46,10 +46,9 @@ const report = {
     version: null,
     url: null,
   },
-  ghcr: {
+  oci: {
     status: 'unknown',
-    image: null,
-    url: null,
+    images: [],
   },
   githubMcp: {
     status: 'unknown',
@@ -114,7 +113,7 @@ async function run() {
   }
 
   await checkNpmPackage(targetEntry.server, targetVersion);
-  await checkOciPackage(targetEntry.server);
+  await checkOciPackages(targetEntry.server);
   await checkGitHubMcpListing(targetEntry.server);
 }
 
@@ -149,25 +148,32 @@ async function checkNpmPackage(server, targetVersion) {
   }
 }
 
-async function checkOciPackage(server) {
-  const ociPackage = server.packages?.find((pkg) => pkg.registryType === 'oci');
+async function checkOciPackages(server) {
+  const ociPackages = server.packages?.filter((pkg) => pkg.registryType === 'oci') ?? [];
 
-  if (!ociPackage) {
+  if (ociPackages.length === 0) {
     report.errors.push(`${server.name}@${server.version} has no OCI package in server.json`);
-    report.ghcr.status = 'missing';
+    report.oci.status = 'missing';
     return;
   }
 
-  const image = String(ociPackage.identifier);
-  const result = await checkOciManifest(image);
+  for (const ociPackage of ociPackages) {
+    const image = String(ociPackage.identifier);
+    const result = await checkOciManifest(image);
 
-  report.ghcr.image = image;
-  report.ghcr.url = result.url;
-  report.ghcr.status = result.ok ? 'ok' : 'failed';
+    report.oci.images.push({
+      image,
+      registry: formatOciRegistryName(image),
+      status: result.ok ? 'ok' : 'failed',
+      url: result.url,
+    });
 
-  if (!result.ok) {
-    report.errors.push(`OCI image ${image} is not available: HTTP ${result.status}`);
+    if (!result.ok) {
+      report.errors.push(`OCI image ${image} is not available: HTTP ${result.status}`);
+    }
   }
+
+  report.oci.status = report.oci.images.every((image) => image.status === 'ok') ? 'ok' : 'failed';
 }
 
 async function checkGitHubMcpListing(server) {
@@ -256,7 +262,8 @@ function selectLatestEntry(entries) {
 
 async function checkOciManifest(identifier) {
   const parsed = parseOciIdentifier(identifier);
-  const url = `https://${parsed.registry}/v2/${parsed.repository}/manifests/${encodeURIComponent(parsed.tag)}`;
+  const registryApiHost = getOciRegistryApiHost(parsed.registry);
+  const url = `https://${registryApiHost}/v2/${parsed.repository}/manifests/${encodeURIComponent(parsed.tag)}`;
   const firstResponse = await fetchWithStatus(url, {
     headers: {
       Accept: manifestAccept,
@@ -323,6 +330,24 @@ function parseOciIdentifier(identifier) {
     repository: image.slice(0, tagSeparator),
     tag: image.slice(tagSeparator + 1),
   };
+}
+
+function getOciRegistryApiHost(registry) {
+  return registry === 'docker.io' ? 'registry-1.docker.io' : registry;
+}
+
+function formatOciRegistryName(identifier) {
+  const parsed = parseOciIdentifier(identifier);
+
+  if (parsed.registry === 'ghcr.io') {
+    return 'GHCR';
+  }
+
+  if (parsed.registry === 'docker.io') {
+    return 'Docker Hub';
+  }
+
+  return parsed.registry;
 }
 
 function createBearerTokenUrl(authHeader, fallbackScope) {
@@ -435,9 +460,17 @@ function printReport(value) {
     `Target version: ${value.targetVersion ?? 'unknown'} (local: ${value.localVersion})`,
     `Official MCP Registry: ${value.officialRegistry.status} (${value.officialRegistry.url})`,
     `npm package: ${value.npm.status} ${value.npm.package}@${value.npm.version ?? 'unknown'}`,
-    `OCI image: ${value.ghcr.status} ${value.ghcr.image ?? 'unknown'}`,
+    `OCI images: ${value.oci.status}`,
     `GitHub MCP Registry: ${value.githubMcp.status}`,
   ];
+
+  if (value.oci.images.length > 0) {
+    lines.push('OCI image URLs checked:');
+
+    for (const image of value.oci.images) {
+      lines.push(`- ${image.registry}: ${image.status} ${image.image} (${image.url})`);
+    }
+  }
 
   if (value.githubMcp.checkedUrls.length > 0) {
     lines.push('GitHub MCP URLs checked:');

--- a/scripts/lib/release-version.mjs
+++ b/scripts/lib/release-version.mjs
@@ -1,6 +1,8 @@
 import { readJson, readText, writeJson, writeText } from './files.mjs';
 
 const markerPattern = /<!-- project-version -->(.*?)<!-- \/project-version -->/gs;
+const packageVersionPattern = String.raw`\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?`;
+const dockerVersionPattern = String.raw`\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:-[0-9A-Za-z.-]+)?`;
 
 export function normalizeReleaseVersion(value) {
   const stripped = value
@@ -77,12 +79,20 @@ export function updatePinnedInstallCommands(filePath, nextVersion, nextDockerVer
   const original = readText(filePath);
   const updated = original
     .replace(
-      /npx -y cloakbrowser-mcp@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/g,
+      new RegExp(`npx -y cloakbrowser-mcp@${packageVersionPattern}`, 'g'),
       `npx -y cloakbrowser-mcp@${nextVersion}`,
     )
     .replace(
-      /ghcr\.io\/swimmwatch\/cloakbrowser-mcp:\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:-[0-9A-Za-z.-]+)?/g,
+      new RegExp(`ghcr\\.io/swimmwatch/cloakbrowser-mcp:${dockerVersionPattern}`, 'g'),
       `ghcr.io/swimmwatch/cloakbrowser-mcp:${nextDockerVersion}`,
+    )
+    .replace(
+      new RegExp(`docker\\.io/swimmwatch/cloakbrowser-mcp:${dockerVersionPattern}`, 'g'),
+      `docker.io/swimmwatch/cloakbrowser-mcp:${nextDockerVersion}`,
+    )
+    .replace(
+      new RegExp(`(^|[\\s"'])swimmwatch/cloakbrowser-mcp:${dockerVersionPattern}`, 'g'),
+      `$1swimmwatch/cloakbrowser-mcp:${nextDockerVersion}`,
     );
 
   writeText(filePath, updated);

--- a/server.json
+++ b/server.json
@@ -202,6 +202,50 @@
           "format": "string"
         }
       ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/swimmwatch/cloakbrowser-mcp:1.2.6",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PLAYWRIGHT_MCP_BROWSER_ENGINE",
+          "description": "Bridge browser engine: cloak or playwright.",
+          "format": "string",
+          "default": "cloak"
+        },
+        {
+          "name": "PLAYWRIGHT_MCP_HEADLESS",
+          "description": "Run the browser in headless mode.",
+          "format": "boolean",
+          "default": "true"
+        },
+        {
+          "name": "PLAYWRIGHT_MCP_OUTPUT_DIR",
+          "description": "Directory inside the container where upstream Playwright MCP writes artifacts.",
+          "format": "filepath",
+          "default": "/data"
+        },
+        {
+          "name": "PLAYWRIGHT_MCP_OUTPUT_MODE",
+          "description": "Return snapshots, console logs, and network logs through stdout or files.",
+          "format": "string",
+          "default": "stdout"
+        },
+        {
+          "name": "CLOAK_PLAYWRIGHT_MCP_CONSOLE_FALLBACK",
+          "description": "Patch upstream console message collection for CloakBrowser compatibility.",
+          "format": "boolean",
+          "default": "true"
+        },
+        {
+          "name": "CLOAK_PLAYWRIGHT_MCP_EXTRA_ARGS",
+          "description": "Comma-separated or JSON array of extra Chromium launch arguments.",
+          "format": "string"
+        }
+      ]
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.swimmwatch/cloakbrowser-mcp",
   "title": "CloakBrowser MCP",
   "description": "Playwright MCP-compatible browser automation bridge for CloakBrowser Chromium.",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "websiteUrl": "https://swimmwatch.github.io/cloakbrowser-mcp/",
   "repository": {
     "url": "https://github.com/swimmwatch/cloakbrowser-mcp",
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "transport": {
         "type": "stdio"
       },
@@ -67,7 +67,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "packageArguments": [
         {
           "type": "named",
@@ -161,7 +161,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.6",
+      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.7",
       "transport": {
         "type": "stdio"
       },
@@ -205,7 +205,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/swimmwatch/cloakbrowser-mcp:1.2.6",
+      "identifier": "docker.io/swimmwatch/cloakbrowser-mcp:1.2.7",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/release-version.test.ts
+++ b/tests/unit/release-version.test.ts
@@ -46,6 +46,7 @@ describe('release version script', () => {
           packages: [
             { registryType: 'npm', version: '0.0.0' },
             { registryType: 'oci', identifier: 'ghcr.io/swimmwatch/cloakbrowser-mcp:0.0.0' },
+            { registryType: 'oci', identifier: 'docker.io/swimmwatch/cloakbrowser-mcp:0.0.0' },
           ],
         },
         null,
@@ -58,7 +59,11 @@ describe('release version script', () => {
     );
     writeFileSync(
       path.join(root, 'docs/getting-started.md'),
-      ['npx -y cloakbrowser-mcp@0.0.0', 'docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:0.0.0'].join('\n'),
+      [
+        'npx -y cloakbrowser-mcp@0.0.0',
+        'docker pull swimmwatch/cloakbrowser-mcp:0.0.0',
+        'docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:0.0.0',
+      ].join('\n'),
     );
 
     const githubOutputPath = path.join(root, 'github-output');
@@ -88,12 +93,18 @@ describe('release version script', () => {
     expect(serverJson.version).toBe('2.3.4-beta.1+build');
     expect(serverJson.packages[0]?.version).toBe('2.3.4-beta.1+build');
     expect(serverJson.packages[1]?.identifier).toBe('ghcr.io/swimmwatch/cloakbrowser-mcp:2.3.4-beta.1-build');
+    expect(serverJson.packages[2]?.identifier).toBe(
+      'docker.io/swimmwatch/cloakbrowser-mcp:2.3.4-beta.1-build',
+    );
     expect(readFileSync(path.join(root, 'docs/index.md'), 'utf8')).toContain('v2.3.4-beta.1+build');
     expect(readFileSync(path.join(root, 'docs/getting-started.md'), 'utf8')).toContain(
       'cloakbrowser-mcp@2.3.4-beta.1+build',
     );
     expect(readFileSync(path.join(root, 'docs/getting-started.md'), 'utf8')).toContain(
       'ghcr.io/swimmwatch/cloakbrowser-mcp:2.3.4-beta.1-build',
+    );
+    expect(readFileSync(path.join(root, 'docs/getting-started.md'), 'utf8')).toContain(
+      'swimmwatch/cloakbrowser-mcp:2.3.4-beta.1-build',
     );
     expect(outputs).toEqual({
       docker_major_minor: '2.3',


### PR DESCRIPTION
## Summary

- publish the release Docker image to Docker Hub in addition to GHCR
- sync Docker Hub repository overview from docs/dockerhub-readme.md
- prepare stable release v1.2.7 metadata and docs
- add a Docker Hub pulls badge to the README

## Security-sensitive changes

- The release workflow now uses DOCKERHUB_USERNAME and DOCKERHUB_TOKEN from the docker-production environment or repository secrets.
- Docker Hub publishing is additive: GHCR remains published, and Docker Hub publishes the public swimmwatch/cloakbrowser-mcp image.
- One docker/build-push-action build still produces the tags, labels, SBOM, and provenance for both registries.

## Validation

- npm run check:ci
- npm run package:verify
- npm run docker:build
- npm run docker:smoke
- npm run bridge:compare -- cloakbrowser-mcp:dev --report bridge-parity-report.json
- docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12 -color
- python3 -m pipx run zizmor --min-severity high .
- npm run docs:build
- npm run docs:seo:validate
