### PR TITLE
build(deps): bump cloakbrowser to 0.3.31

### DIFF
--- a/.agents/skills/project-pull-request/SKILL.md
+++ b/.agents/skills/project-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-pull-request
-description: Use when creating, updating, or reviewing a cloakbrowser-mcp GitHub Pull Request. Defines branch, base/head, title, required PR body template, checklist, security review, test evidence, and post-create reporting rules.
+description: Use when creating, updating, or reviewing a cloakbrowser-mcp GitHub Pull Request. Defines branch, base/head, assignee, title, required PR body template, checklist, security review, test evidence, and post-create reporting rules.
 ---
 
 # Project Pull Request
@@ -20,6 +20,15 @@ replace it with a second template.
 - Push the current feature branch to `origin` before creating the PR.
 - Create PRs ready for review by default. Use draft only when the user
   explicitly asks for a draft PR.
+
+## Assignee
+
+- Assign the PR to the authenticated GitHub user by default. Resolve the login
+  with `gh api user --jq .login` or the equivalent GitHub connector identity.
+- For this repository, the expected default assignee is `swimmwatch` unless the
+  user explicitly requests another assignee.
+- If the assignee cannot be resolved or GitHub rejects it, report the blocker
+  and leave the PR otherwise complete.
 
 ## Title
 
@@ -51,4 +60,5 @@ Do not leave HTML comments or placeholder text in the submitted PR body.
 - If a PR already exists for the branch, update its title/body instead of
   creating a duplicate.
 - After creating or updating the PR, report the PR URL, base/head branches,
-  title, whether it is draft or ready for review, and any skipped checks.
+  title, assignee, whether it is draft or ready for review, and any skipped
+  checks.

--- a/.agents/skills/project-pull-request/SKILL.md
+++ b/.agents/skills/project-pull-request/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: project-pull-request
+description: Use when creating, updating, or reviewing a cloakbrowser-mcp GitHub Pull Request. Defines branch, base/head, title, required PR body template, checklist, security review, test evidence, and post-create reporting rules.
+---
+
+# Project Pull Request
+
+Use this skill for `cloakbrowser-mcp` Pull Request work. The repository's
+`.github/PULL_REQUEST_TEMPLATE.md` is the required PR body format; do not
+replace it with a second template.
+
+## Preconditions
+
+- Inspect `git status`, current branch, upstream tracking, and diff before
+  creating or updating a PR.
+- Do not open a PR from `main`.
+- Use `main` as the base branch unless the user explicitly gives another base.
+- Before creating a commit for the PR, open and scan
+  `https://www.conventionalcommits.org/en/v1.0.0/`.
+- Push the current feature branch to `origin` before creating the PR.
+- Create PRs ready for review by default. Use draft only when the user
+  explicitly asks for a draft PR.
+
+## Title
+
+- Use a concise Conventional-style title, such as
+  `build(deps): bump cloakbrowser to 0.3.31`.
+- Use imperative or present-tense wording after the conventional prefix.
+- Make the title describe the main branch change, not a test result or
+  implementation detail.
+
+## Body
+
+Fill every section from `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- `Summary`: include 2-4 bullets explaining what changed and why.
+- `Checklist`: keep every template item. Mark `[x]` only when completed. If an
+  item is not applicable, keep it visible and add a short reason.
+- `Security review`: write explicit notes even when there is no new risk.
+  Mention bridge, child-process, filesystem, Docker, logging, secrets/tokens,
+  OIDC, and registry publishing when relevant.
+- `Test evidence`: list exact commands and outcomes. If a relevant check was
+  skipped, state why.
+
+Do not leave HTML comments or placeholder text in the submitted PR body.
+
+## Create Or Update
+
+- Prefer the available GitHub app or connector. Use `gh` when connector support
+  is unavailable or insufficient.
+- If a PR already exists for the branch, update its title/body instead of
+  creating a duplicate.
+- After creating or updating the PR, report the PR URL, base/head branches,
+  title, whether it is draft or ready for review, and any skipped checks.

--- a/.agents/skills/project-release/SKILL.md
+++ b/.agents/skills/project-release/SKILL.md
@@ -109,6 +109,8 @@ the smallest release-relevant cause and rerun the relevant command.
 ## PR And Release Flow
 
 - Commit release preparation as `chore(release): prepare vX.Y.Z`.
+- For release PR creation or updates, also read and follow
+  `.agents/skills/project-pull-request/SKILL.md`.
 - Open a PR to `main` with a concise release summary and validation list.
 - Call out security-sensitive release workflow changes, especially registry
   credentials, public image publishing, OIDC, or token behavior.

--- a/.agents/skills/project-release/SKILL.md
+++ b/.agents/skills/project-release/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: project-release
+description: Use when preparing, publishing, verifying, or recovering a cloakbrowser-mcp release. Requires a confirmed target version such as v1.2.8, can propose one from changes since the previous release, and guides branch, version metadata, changelog, PR, GitHub Release, registry, Docker, npm, and docs verification.
+---
+
+# Project Release
+
+Use this skill only for `cloakbrowser-mcp` release work. Require a confirmed
+target version such as `v1.2.8`, and decide whether it is stable or prerelease
+before preparing, publishing, or recovering a release. If the user has not
+provided a target version, propose one from the unreleased changes and ask the
+user to confirm it or choose a different tag before release execution.
+
+Release tags use Semantic Versioning 2.0.0 with the repository's `v` prefix,
+for example `v1.2.8` or `v1.2.8-rc.1`. The pinned specification URL is
+`https://semver.org/spec/v2.0.0.html`.
+
+## Choosing The Target Version
+
+- If the user provides a target tag, validate it before changing files.
+- If no target tag is provided, fetch tags and inspect changes since the
+  previous release tag:
+
+```bash
+git fetch origin --tags --prune
+git describe --tags --abbrev=0
+git log --oneline <previous-tag>..HEAD
+```
+
+- Also inspect `[Unreleased]` in `CHANGELOG.md`, merged PR titles, and
+  Conventional Commit subjects when available.
+- Propose the next tag using Semantic Versioning 2.0.0:
+  - `MAJOR` for backward-incompatible public API, CLI, MCP protocol, config, or
+    artifact contract changes;
+  - `MINOR` for backward-compatible user-facing features;
+  - `PATCH` for backward-compatible fixes, dependency updates, docs, CI, or
+    packaging-only changes.
+- Present the proposed tag and short rationale, then ask the user to confirm it
+  or choose another tag. Do not run `npm run version:apply` until the tag is
+  confirmed.
+
+## Preconditions
+
+- Start from a clean worktree; do not overwrite unrelated user changes.
+- Fetch latest refs and branch from current `main` unless the user explicitly
+  gives another base.
+- Confirm no existing Git tag or GitHub Release already uses the target version.
+- Before confirming the release tag, open and scan
+  `https://semver.org/spec/v2.0.0.html`, then validate that the requested tag
+  is the `v`-prefixed form of a SemVer 2.0.0 version.
+- Exclude known failing or unrelated dependency PRs unless the user explicitly
+  includes them.
+- Before editing `CHANGELOG.md`, open and scan
+  `https://keepachangelog.com/en/1.1.0/`.
+- Before committing, open and scan
+  `https://www.conventionalcommits.org/en/v1.0.0/`.
+
+## Version Preparation
+
+Run the release version script with the exact tag:
+
+```bash
+npm run version:apply -- vX.Y.Z
+```
+
+The script updates:
+
+- `package.json`
+- `package-lock.json`
+- `server.json`
+- the project-version marker in `docs/index.md`
+- pinned npm and Docker install commands in `docs/getting-started.md`
+
+Manual release updates still required:
+
+- add the new row to the compatibility tables in `README.md`,
+  `docs/index.md`, and `docs/version-compatibility.md`;
+- verify each new row records the actual `@playwright/mcp`, Playwright MCP
+  Docker base, CloakBrowser dependency, supported transport, and platform;
+- move current `[Unreleased]` entries in `CHANGELOG.md` into
+  `## [X.Y.Z] - YYYY-MM-DD`;
+- add or update the empty `[Unreleased]` section above the new release;
+- update changelog compare links so `[Unreleased]` compares
+  `vX.Y.Z...HEAD` and `[X.Y.Z]` compares the previous tag to `vX.Y.Z`;
+- update release docs examples only if they are intended to show the current
+  release instead of a generic example.
+
+Do not bump the package version outside release preparation.
+
+## Validation
+
+Before opening or merging the release PR, run:
+
+```bash
+npm run check:ci
+npm run package:verify
+npm run docker:build
+npm run docker:smoke
+npm run bridge:compare -- cloakbrowser-mcp:dev --report bridge-parity-report.json
+docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12 -color
+python3 -m pipx run zizmor --min-severity high .
+npm run docs:build
+npm run docs:seo:validate
+```
+
+Remove `bridge-parity-report.json` after inspecting it. If a check fails, fix
+the smallest release-relevant cause and rerun the relevant command.
+
+## PR And Release Flow
+
+- Commit release preparation as `chore(release): prepare vX.Y.Z`.
+- Open a PR to `main` with a concise release summary and validation list.
+- Call out security-sensitive release workflow changes, especially registry
+  credentials, public image publishing, OIDC, or token behavior.
+- Wait for required PR checks to pass before merging.
+- For stable releases, create a published GitHub Release with:
+  - tag `vX.Y.Z`;
+  - target `main`;
+  - title `vX.Y.Z`;
+  - notes from the `CHANGELOG.md` section.
+- Mark prerelease versions as GitHub prereleases. Stable releases publish npm
+  `latest` and Docker `latest`; prereleases publish npm `next` and prerelease
+  Docker tags only.
+
+## Post-Release Verification
+
+Watch the unified `Release` workflow until `metadata`, `npm`, `docker`,
+`docs-build`, `docs-deploy`, and `mcp-registry` complete.
+
+Then verify:
+
+```bash
+npm view cloakbrowser-mcp@X.Y.Z version
+docker pull swimmwatch/cloakbrowser-mcp:X.Y.Z
+docker run --rm --init swimmwatch/cloakbrowser-mcp:X.Y.Z --help
+docker pull ghcr.io/swimmwatch/cloakbrowser-mcp:X.Y.Z
+npm run registry:check -- --version X.Y.Z
+```
+
+Confirm Docker Hub overview, short description, npm, GHCR, Docker Hub, docs,
+and the official MCP Registry are current. GitHub `/mcp` visibility is curated
+separately and may lag; treat it as a warning unless the user makes it a gate.
+
+## Recovery
+
+- If Docker Hub overview update fails with `Forbidden`, the
+  `DOCKERHUB_TOKEN` secret needs a Docker Hub personal access token with
+  read/write/delete permissions for `swimmwatch/cloakbrowser-mcp`; rerun failed
+  release jobs after the secret is updated.
+- If npm, GHCR, Docker Hub, or MCP Registry already published artifacts, do not
+  delete and retag the same release for code defects. Prepare a follow-up patch
+  release instead.
+- Rerun failed jobs only after confirming the failure is transient or caused by
+  a fixed external configuration.
+- Keep release recovery notes in the final status report, including published
+  artifact state and any warnings.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# Repository Instructions
+
+Follow `AGENTS.md` for project-wide coding, testing, documentation, changelog,
+and commit rules.
+
+For release preparation, publishing, verification, or recovery tasks, read
+`.agents/skills/project-release/SKILL.md` before making changes. That file is
+the authoritative release workflow for this repository.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,3 +6,6 @@ and commit rules.
 For release preparation, publishing, verification, or recovery tasks, read
 `.agents/skills/project-release/SKILL.md` before making changes. That file is
 the authoritative release workflow for this repository.
+
+For Pull Request creation, updates, or review-prep tasks, read
+`.agents/skills/project-pull-request/SKILL.md` before creating or editing a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ npm run check
 
 Update `README.md`, `docs/getting-started.md`, `docs/configuration.md`, `docs/docker.md`, or `docs/tools.md` when public CLI, Docker, environment, or tool-surface behavior changes.
 
+For release preparation, publishing, verification, or recovery requests, read and follow `.agents/skills/project-release/SKILL.md`.
+
 `CHANGELOG.md` must follow Keep a Changelog `1.1.0`. The pinned specification URL is `https://keepachangelog.com/en/1.1.0/`. Before editing release notes, open and scan that specification, then write human-readable entries in reverse chronological order with an `[Unreleased]` section, ISO dates, comparison links, and standard sections such as `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security`.
 
 ## Commit And PR Hygiene

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ Update `README.md`, `docs/getting-started.md`, `docs/configuration.md`, `docs/do
 
 For release preparation, publishing, verification, or recovery requests, read and follow `.agents/skills/project-release/SKILL.md`.
 
+For Pull Request creation, updates, or review-prep requests, read and follow `.agents/skills/project-pull-request/SKILL.md`.
+
 `CHANGELOG.md` must follow Keep a Changelog `1.1.0`. The pinned specification URL is `https://keepachangelog.com/en/1.1.0/`. Before editing release notes, open and scan that specification, then write human-readable entries in reverse chronological order with an `[Unreleased]` section, ISO dates, comparison links, and standard sections such as `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security`.
 
 ## Commit And PR Hygiene

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a project release skill for AI agents to prepare, publish, verify, and
+  recover releases.
+
+### Changed
+
+- Updated CloakBrowser dependency to `^0.3.31`.
+
 ## [1.2.7] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Updated CloakBrowser dependency to `^0.3.31`.
+- Updated the project Pull Request skill to assign PRs to the authenticated
+  GitHub user by default.
 
 ## [1.2.7] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added a project release skill for AI agents to prepare, publish, verify, and
   recover releases.
+- Added a project Pull Request skill for AI agents to prepare, create, update,
+  and report PRs consistently.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",
         "@playwright/mcp": "^0.0.75",
-        "cloakbrowser": "^0.3.30",
+        "cloakbrowser": "^0.3.31",
         "commander": "^14.0.3"
       },
       "bin": {
@@ -2059,9 +2059,9 @@
       }
     },
     "node_modules/cloakbrowser": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.3.30.tgz",
-      "integrity": "sha512-e7kDZzOmqRn9VOFskTDLU6rFqj+TYj68942XFqs2m+CC5G8yHwkHhitjMQJaI/c5Zvl7Aez/kf1JjO/b3VqYaA==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.3.31.tgz",
+      "integrity": "sha512-HtwlpwFKd5FJh4jjCS5awsScWIKB9ofNSTkHLSEh/9JH0Hv1L79zu0MExSMOCP1nzOsgrohbacwwWocuKloQ1A==",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.0",
     "@playwright/mcp": "^0.0.75",
-    "cloakbrowser": "^0.3.30",
+    "cloakbrowser": "^0.3.31",
     "commander": "^14.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bumps the `cloakbrowser` dependency to `^0.3.31` and refreshes the npm lockfile.
- Adds repo-local agent skills for release and Pull Request workflows under `.agents/skills`.
- Points AGENTS and Copilot instructions at the shared skill files so assistants use the same release and PR rules.
- Updates the Unreleased changelog entries for the dependency bump and new agent skills.

## Checklist

- [x] I ran `npm run check` locally and it passed.
- [x] If I changed public behavior, I updated `README.md` and relevant docs in `docs/`. N/A: no public CLI, Docker, environment, or tool-surface behavior changed.
- [x] If I changed local bridge tools, I updated `docs/tools.md`. N/A: no local bridge tool changes.
- [x] If I changed bridge configuration, I updated `docs/configuration.md`. N/A: no bridge configuration changes.
- [x] Upstream Playwright MCP tool schemas, descriptions, and responses are not copied or mutated.
- [x] I added/updated tests (unit and/or integration as appropriate). N/A: no runtime code path or protocol contract changed; existing unit and integration suites passed.
- [x] I added an entry to `CHANGELOG.md` under `## [Unreleased]`.
- [x] I reviewed security implications and documented them below.

## Security review

- Bridge: no changes to proxy behavior, local MCP tools, or upstream Playwright MCP tool contracts.
- Child-process, filesystem, and logging: no runtime implementation changes; stdio behavior is unchanged.
- Docker, secrets, tokens, OIDC, and registry publishing: no workflow, credential, or publishing behavior changes in this PR.
- Dependency: updates `cloakbrowser` from `^0.3.30` to `^0.3.31`; local package, Docker smoke, and bridge parity checks passed.

## Test evidence

- `npm run check` passed.
- `npm run check:ci` passed.
- `npm run package:verify` passed.
- `npm run docker:build` passed.
- `npm run docker:smoke` passed.
- `npm run bridge:compare -- cloakbrowser-mcp:dev --report bridge-parity-report.json` passed; `bridge-parity-report.json` was removed after inspection.
- `docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12 -color` passed.
- `python3 -m pipx run zizmor --min-severity high .` passed.
- `npm run docs:build` passed.
- `npm run docs:seo:validate` passed.
- Project skill frontmatter parser checks passed.
- `git diff --check` passed.
- `npm run format:check` passed.
