### PR TITLE
feat: add HTTP probes and doctor command

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,15 @@ updates:
     schedule:
       interval: weekly
 
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: weekly
+    groups:
+      docs-dependencies:
+        patterns:
+          - '*'
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,15 +19,13 @@ permissions:
   contents: read
 
 env:
-  ACTIONLINT_IMAGE_REGISTRY: docker.io
-  ACTIONLINT_IMAGE_NAME: rhysd/actionlint
-  ACTIONLINT_IMAGE_TAG: 1.7.12
+  ACTIONLINT_IMAGE_REF: docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
 
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run actionlint
-        run: docker run --rm -v "$PWD:/repo" --workdir /repo "$ACTIONLINT_IMAGE_REGISTRY/$ACTIONLINT_IMAGE_NAME:$ACTIONLINT_IMAGE_TAG" -color
+        run: docker run --rm -v "$PWD:/repo" --workdir /repo "$ACTIONLINT_IMAGE_REF" -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,13 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 env:
   CI_DOCKER_IMAGE: cloakbrowser-mcp:ci
   DOCKER_CACHE_SCOPE: cloakbrowser-mcp-docker
   NODE_CHECK_VERSIONS: '["20", "21", "22", "23", "24", "25", "26"]'
-  NODE_IMAGE_TAG: 22-bookworm-slim
-  PLAYWRIGHT_MCP_IMAGE: mcr.microsoft.com/playwright/mcp:v0.0.75
+  NODE_IMAGE_REF: node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732
+  PLAYWRIGHT_MCP_IMAGE: mcr.microsoft.com/playwright/mcp:v0.0.75@sha256:d238ec7bc98cc4e22df0696d6031dad5b8a4b46781f4f0abaa3bfadeedb43b9a
 
 jobs:
   node-versions:
@@ -33,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -49,8 +48,8 @@ jobs:
       matrix:
         node-version: ${{ fromJSON(needs.node-versions.outputs.node_versions) }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -74,21 +73,21 @@ jobs:
       matrix:
         node-version: ${{ fromJSON(needs.node-versions.outputs.node_versions) }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run test:coverage
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage/lcov.info
           flags: vitest,node${{ matrix.node-version }}
           name: vitest-node${{ matrix.node-version }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-node${{ matrix.node-version }}
           path: coverage/
@@ -98,15 +97,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
       - run: npm ci --ignore-scripts
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: pip
@@ -124,9 +123,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -137,7 +139,7 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "version_tag=v$version" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - id: base
         name: Resolve Playwright MCP base digest
         run: |
@@ -148,14 +150,14 @@ jobs:
           fi
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true
           pull: true
           tags: ${{ env.CI_DOCKER_IMAGE }}
           build-args: |
-            NODE_IMAGE_TAG=${{ env.NODE_IMAGE_TAG }}
+            NODE_IMAGE_REF=${{ env.NODE_IMAGE_REF }}
             PLAYWRIGHT_MCP_IMAGE=${{ env.PLAYWRIGHT_MCP_IMAGE }}
             PLAYWRIGHT_MCP_IMAGE_DIGEST=${{ steps.base.outputs.digest }}
             RELEASE_VERSION=${{ steps.package.outputs.version }}
@@ -167,14 +169,14 @@ jobs:
         run: docker run --rm --init "$CI_DOCKER_IMAGE" --help
       - name: Compare with upstream Playwright MCP
         run: npm run bridge:compare -- "$CI_DOCKER_IMAGE" --report bridge-parity-report.json
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: bridge-parity-report
           path: bridge-parity-report.json
           if-no-files-found: warn
       - name: Scan Docker image
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.CI_DOCKER_IMAGE }}
           version: v0.70.0
@@ -185,7 +187,7 @@ jobs:
           vuln-type: os,library
           ignore-unfixed: true
           exit-code: '1'
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: trivy-results
@@ -193,6 +195,6 @@ jobs:
           if-no-files-found: warn
       - name: Upload Trivy SARIF
         if: always() && github.event_name != 'pull_request' && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,20 @@ permissions:
 env:
   CI_DOCKER_IMAGE: cloakbrowser-mcp:ci
   DOCKER_CACHE_SCOPE: cloakbrowser-mcp-docker
+  NODE_CHECK_VERSIONS: '["20", "21", "22", "23", "24", "25", "26"]'
   NODE_IMAGE_TAG: 22-bookworm-slim
   PLAYWRIGHT_MCP_IMAGE: mcr.microsoft.com/playwright/mcp:v0.0.75
 
 jobs:
+  node-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      node_versions: ${{ steps.versions.outputs.node_versions }}
+    steps:
+      - id: versions
+        run: echo "node_versions=$NODE_CHECK_VERSIONS" >> "$GITHUB_OUTPUT"
+
   npm-audit:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -33,10 +43,11 @@ jobs:
 
   quality:
     runs-on: ubuntu-latest
+    needs: node-versions
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 21, 22, 23, 24, 25, 26]
+        node-version: ${{ fromJSON(needs.node-versions.outputs.node_versions) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -55,11 +66,13 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    needs: quality
+    needs:
+      - node-versions
+      - quality
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 21, 22, 23, 24, 25, 26]
+        node-version: ${{ fromJSON(needs.node-versions.outputs.node_versions) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 21, 22, 23, 24, 25, 26]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -56,24 +56,28 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     needs: quality
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 21, 22, 23, 24, 25, 26]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run test:coverage
       - uses: codecov/codecov-action@v6
         with:
           files: ./coverage/lcov.info
-          flags: vitest
-          name: vitest-node20
+          flags: vitest,node${{ matrix.node-version }}
+          name: vitest-node${{ matrix.node-version }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         with:
-          name: coverage
+          name: coverage-node${{ matrix.node-version }}
           path: coverage/
           if-no-files-found: error
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,19 +16,23 @@ permissions:
   actions: read
   contents: read
   packages: read
-  security-events: write
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
   NPM_NODE_VERSION: '24'
   NPM_CONFIG_AUDIT: 'false'
   NPM_CONFIG_FUND: 'false'
-  NODE_IMAGE_TAG: 22-bookworm-slim
+  NODE_IMAGE_REF: node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732
   DOCKER_REGISTRY: ghcr.io
   DOCKERHUB_IMAGE: swimmwatch/cloakbrowser-mcp
   IMAGE_NAME: cloakbrowser-mcp
@@ -35,7 +35,7 @@ env:
   MCP_SERVER_NAME: io.github.swimmwatch/cloakbrowser-mcp
   DOCKER_PLATFORMS: linux/amd64
   DOCKER_CACHE_SCOPE: cloakbrowser-mcp-docker
-  PLAYWRIGHT_MCP_IMAGE: mcr.microsoft.com/playwright/mcp:v0.0.75
+  PLAYWRIGHT_MCP_IMAGE: mcr.microsoft.com/playwright/mcp:v0.0.75@sha256:d238ec7bc98cc4e22df0696d6031dad5b8a4b46781f4f0abaa3bfadeedb43b9a
   MCP_REGISTRY_API_URL: https://registry.modelcontextprotocol.io/v0.1
 
 jobs:
@@ -53,9 +53,9 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       version_tag: ${{ steps.release.outputs.version_tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -93,9 +93,9 @@ jobs:
       matrix:
         node-version: [20, 21, 22, 23, 24, 25, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           package-manager-cache: false
@@ -121,9 +121,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NPM_NODE_VERSION }}
           registry-url: https://registry.npmjs.org
@@ -174,7 +174,7 @@ jobs:
           RELEASE_VERSION_TAG: ${{ needs.metadata.outputs.version_tag }}
         run: npm run package:verify
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: npm-package-${{ needs.metadata.outputs.version_tag }}
           path: ${{ steps.pack.outputs.package_file }}
@@ -200,9 +200,9 @@ jobs:
       packages: write
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -217,7 +217,7 @@ jobs:
       - name: Export release image names
         run: echo "RELEASE_SMOKE_IMAGE=${IMAGE_NAME}:${{ needs.metadata.outputs.docker_tag }}-smoke" >> "$GITHUB_ENV"
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - id: base
         name: Resolve Playwright MCP base digest
@@ -230,14 +230,14 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Build image for smoke test
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true
           pull: true
           tags: ${{ env.RELEASE_SMOKE_IMAGE }}
           build-args: |
-            NODE_IMAGE_TAG=${{ env.NODE_IMAGE_TAG }}
+            NODE_IMAGE_REF=${{ env.NODE_IMAGE_REF }}
             PLAYWRIGHT_MCP_IMAGE=${{ env.PLAYWRIGHT_MCP_IMAGE }}
             PLAYWRIGHT_MCP_IMAGE_DIGEST=${{ steps.base.outputs.digest }}
             RELEASE_VERSION=${{ needs.metadata.outputs.version }}
@@ -252,7 +252,7 @@ jobs:
       - name: Compare release image with upstream Playwright MCP
         run: npm run bridge:compare -- "$RELEASE_SMOKE_IMAGE" --report bridge-parity-report.json
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: bridge-parity-report-${{ needs.metadata.outputs.version_tag }}
@@ -261,7 +261,7 @@ jobs:
           retention-days: 14
 
       - name: Scan release image
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.RELEASE_SMOKE_IMAGE }}
           version: v0.70.0
@@ -273,7 +273,7 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: trivy-results-${{ needs.metadata.outputs.version_tag }}
@@ -283,25 +283,25 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-results.sarif
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: |
             ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
@@ -327,7 +327,7 @@ jobs:
             org.opencontainers.image.base.digest=${{ steps.base.outputs.digest }}
             io.modelcontextprotocol.server.name=${{ env.MCP_SERVER_NAME }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true
@@ -336,7 +336,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NODE_IMAGE_TAG=${{ env.NODE_IMAGE_TAG }}
+            NODE_IMAGE_REF=${{ env.NODE_IMAGE_REF }}
             PLAYWRIGHT_MCP_IMAGE=${{ env.PLAYWRIGHT_MCP_IMAGE }}
             PLAYWRIGHT_MCP_IMAGE_DIGEST=${{ steps.base.outputs.digest }}
             RELEASE_VERSION=${{ needs.metadata.outputs.version }}
@@ -348,7 +348,7 @@ jobs:
           provenance: mode=max
 
       - name: Update Docker Hub overview
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -370,11 +370,11 @@ jobs:
       NAVER_SITE_VERIFICATION: ${{ vars.NAVER_SITE_VERIFICATION || secrets.NAVER_SITE_VERIFICATION || '' }}
       YANDEX_SITE_VERIFICATION: ${{ vars.YANDEX_SITE_VERIFICATION || secrets.YANDEX_SITE_VERIFICATION || '' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -386,11 +386,11 @@ jobs:
           RELEASE_VERSION_TAG: ${{ needs.metadata.outputs.version_tag }}
         run: npm run version:apply -- "$RELEASE_VERSION_TAG"
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
-      - run: pip install -r docs/requirements.txt
+      - run: npm run docs:install
 
       - name: Install docs asset tooling
         run: |
@@ -403,13 +403,13 @@ jobs:
         if: ${{ env.INDEXNOW_KEY != '' }}
         run: node scripts/write-indexnow-key.mjs
 
-      - run: mkdocs build --strict
+      - run: npm run docs:build
 
       - run: npm run docs:seo:validate
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site/
 
@@ -427,15 +427,15 @@ jobs:
     env:
       INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
 
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
       - name: Notify IndexNow
         if: ${{ env.INDEXNOW_KEY != '' }}
@@ -455,9 +455,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,39 @@ jobs:
             echo "npm_dist_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-  npm:
+  release-checks:
     runs-on: ubuntu-latest
     needs: metadata
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 21, 22, 23, 24, 25, 26]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
+
+      - run: npm ci --ignore-scripts
+
+      - name: Apply release version from tag
+        env:
+          RELEASE_VERSION_TAG: ${{ needs.metadata.outputs.version_tag }}
+        run: npm run version:apply -- "$RELEASE_VERSION_TAG"
+
+      - name: Run release checks
+        run: npm run check:ci
+
+  npm:
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - release-checks
     timeout-minutes: 25
     environment: npm-production
     permissions:
@@ -137,8 +167,6 @@ jobs:
             exit 1
           fi
 
-      - run: npm run check:ci
-
       - id: pack
         name: Pack and verify npm tarball
         env:
@@ -161,7 +189,9 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
-    needs: metadata
+    needs:
+      - metadata
+      - release-checks
     timeout-minutes: 60
     environment: docker-production
     permissions:
@@ -183,9 +213,6 @@ jobs:
         env:
           RELEASE_VERSION_TAG: ${{ needs.metadata.outputs.version_tag }}
         run: npm run version:apply -- "$RELEASE_VERSION_TAG"
-
-      - name: Run release checks
-        run: npm run check:ci
 
       - name: Export release image names
         run: echo "RELEASE_SMOKE_IMAGE=${IMAGE_NAME}:${{ needs.metadata.outputs.docker_tag }}-smoke" >> "$GITHUB_ENV"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,17 +23,17 @@ jobs:
       id-token: write
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true
 
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: scorecard-results.sarif

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,14 +23,13 @@ jobs:
   zizmor:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run zizmor
-        run: |
-          python3 -m pip install --user pipx
-          python3 -m pipx run zizmor --min-severity high .
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          min-severity: high

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,4 @@
 rules:
-  unpinned-uses:
-    disable: true
   cache-poisoning:
     ignore:
       - ci.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ For Pull Request creation, updates, or review-prep requests, read and follow `.a
 ## Commit And PR Hygiene
 
 - One logical change per commit.
+- Before creating a commit for local changes, ask the user for explicit confirmation that the commit should be created.
 - Commit messages must follow Conventional Commits `1.0.0`.
 - The pinned specification URL is `https://www.conventionalcommits.org/en/v1.0.0/`.
 - Before creating a commit, open and scan the pinned specification, then choose the commit `type`, optional `scope`, optional breaking-change marker, subject, body, and footers according to that version.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,38 @@ npm run check
 - Integration tests live under `tests/integration/`.
 - Use the fake upstream MCP server for proxy behavior.
 - Tests must write only to `tmpdir()` paths they create and clean up.
+- Prefer property-based tests for parsers, option normalization, environment
+  handling, and other boundary-heavy pure logic.
+
+## Supply Chain And GitHub Security
+
+- Keep GitHub workflow permissions least-privilege: use top-level
+  `contents: read`, and declare write permissions only on the specific job that
+  needs them.
+- Pin external GitHub Actions by full commit SHA. Keep the intended upstream
+  version in a trailing comment, for example `# v6`, so updates remain
+  reviewable.
+- Pin Docker images used by the Dockerfile and workflows with `tag@sha256:...`
+  references. Preserve the readable tag next to the digest.
+- Use image reference variables such as `NODE_IMAGE_REF` for pinned image refs;
+  avoid tag-only variables for build inputs.
+- When changing the pinned upstream Playwright MCP image, keep
+  `scripts/lib/playwright-mcp-upstream.mjs` able to read the tag from a
+  `tag@sha256:...` value.
+- Do not disable zizmor or OpenSSF Scorecard findings broadly. Suppress only a
+  narrowly scoped finding with a clear reason.
+- Run actionlint and zizmor after workflow, Docker, token permission, or
+  registry publishing changes:
+
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
+python3 -m pipx run zizmor --min-severity high .
+```
+
+- Keep `SECURITY.md` actionable with a private vulnerability reporting path.
+- Repository settings such as branch protection, rulesets, required reviewers,
+  and required checks are maintainer-controlled. Do not change them without
+  explicit confirmation of the exact policy.
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   readiness checks.
 - Added the `cloakbrowser-mcp doctor` diagnostics command with human and JSON
   output.
+- Added a stable upstream Playwright MCP tool list reference to the Tools
+  documentation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Updated CloakBrowser dependency to `^0.3.31`.
+- Updated documentation dependency minimums for MkDocs plugins.
 - Expanded Node.js workflow check coverage across major versions 20 through
   26.
 - Updated the project Pull Request skill to assign PRs to the authenticated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Updated CloakBrowser dependency to `^0.3.31`.
+- Expanded Node.js workflow check coverage across major versions 20 through
+  26.
 - Updated the project Pull Request skill to assign PRs to the authenticated
   GitHub user by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   recover releases.
 - Added a project Pull Request skill for AI agents to prepare, create, update,
   and report PRs consistently.
+- Added Streamable HTTP `GET /healthz` and `GET /readyz` probes for health and
+  readiness checks.
+- Added the `cloakbrowser-mcp doctor` diagnostics command with human and JSON
+  output.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   recover releases.
 - Added a project Pull Request skill for AI agents to prepare, create, update,
   and report PRs consistently.
+- Added property-based tests for CLI and environment parsing.
+- Added agent instructions for supply-chain hardening and GitHub security
+  changes.
 - Added Streamable HTTP `GET /healthz` and `GET /readyz` probes for health and
   readiness checks.
 - Added the `cloakbrowser-mcp doctor` diagnostics command with human and JSON
@@ -22,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Added the Advanced SEO MkDocs plugin for generated documentation metadata.
+- Hardened GitHub workflow token permissions and pinned workflow actions.
 - Updated CloakBrowser dependency to `^0.3.31`.
 - Updated documentation dependency minimums for MkDocs plugins.
 - Updated npm development dependency minimums to current compatible releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Added the Advanced SEO MkDocs plugin for generated documentation metadata.
 - Updated CloakBrowser dependency to `^0.3.31`.
 - Updated documentation dependency minimums for MkDocs plugins.
 - Updated npm development dependency minimums to current compatible releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Updated CloakBrowser dependency to `^0.3.31`.
 - Updated documentation dependency minimums for MkDocs plugins.
+- Updated npm development dependency minimums to current compatible releases.
 - Expanded Node.js workflow check coverage across major versions 20 through
   26.
 - Updated the project Pull Request skill to assign PRs to the authenticated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
-ARG NODE_IMAGE_TAG=22-bookworm-slim
-ARG PLAYWRIGHT_MCP_IMAGE=mcr.microsoft.com/playwright/mcp:v0.0.75
+ARG NODE_IMAGE_REF=node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732
+ARG PLAYWRIGHT_MCP_IMAGE=mcr.microsoft.com/playwright/mcp:v0.0.75@sha256:d238ec7bc98cc4e22df0696d6031dad5b8a4b46781f4f0abaa3bfadeedb43b9a
 
-FROM node:${NODE_IMAGE_TAG} AS deps
+FROM ${NODE_IMAGE_REF} AS deps
 WORKDIR /src
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
@@ -21,7 +21,7 @@ RUN npm prune --omit=dev --ignore-scripts \
  && npm cache clean --force
 
 FROM ${PLAYWRIGHT_MCP_IMAGE} AS runtime
-ARG PLAYWRIGHT_MCP_IMAGE=mcr.microsoft.com/playwright/mcp:v0.0.75
+ARG PLAYWRIGHT_MCP_IMAGE=mcr.microsoft.com/playwright/mcp:v0.0.75@sha256:d238ec7bc98cc4e22df0696d6031dad5b8a4b46781f4f0abaa3bfadeedb43b9a
 ARG PLAYWRIGHT_MCP_IMAGE_DIGEST=unknown
 ARG RELEASE_VERSION=0.0.0
 ARG RELEASE_VERSION_TAG=v0.0.0

--- a/README.md
+++ b/README.md
@@ -66,12 +66,15 @@ Use `npm run registry:check:strict` only when GitHub MCP listing visibility shou
 
 ```bash
 npx -y cloakbrowser-mcp@latest --help
+npx -y cloakbrowser-mcp@latest doctor
+npx -y cloakbrowser-mcp@latest doctor --json
 npx -y cloakbrowser-mcp@latest
 npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 ```
 
 Requires Node.js 20 or newer. The first real browser action may download the CloakBrowser binary unless it is already cached.
-The default transport is stdio. Streamable HTTP binds to `127.0.0.1` by default and serves MCP at `/mcp`.
+Use `doctor` for local diagnostics before connecting an MCP client. It checks the Node.js engine, project metadata, upstream Playwright MCP resolution, and CloakBrowser binary metadata without starting the bridge or downloading a browser.
+The default transport is stdio. Streamable HTTP binds to `127.0.0.1` by default, serves MCP at `/mcp`, and exposes fixed `GET /healthz` and `GET /readyz` probes. If `--http-auth-token` is set, the probes require the same `Authorization: Bearer ...` header as MCP requests.
 For the complete generated CLI flag reference, see the published [CLI Reference](https://swimmwatch.github.io/cloakbrowser-mcp/generated/cli/).
 
 ## Run from Docker
@@ -86,6 +89,9 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
   -v "$PWD/artifacts:/data" \
   swimmwatch/cloakbrowser-mcp:latest \
   --transport streamable-http --http-host 0.0.0.0 --http-port 3000
+
+curl http://127.0.0.1:3000/healthz
+curl http://127.0.0.1:3000/readyz
 ```
 
 The Docker image is based on the pinned official Playwright MCP image, installs the bridge under `/opt/cloakbrowser-mcp`, and writes artifacts to `/data` by default.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,11 @@ The project has not published a stable release yet. Security fixes are applied t
 
 Please report vulnerabilities through **GitHub Security Advisories** (private reporting):
 
-1. Open the repository on GitHub.
-2. Go to the **Security** tab.
-3. Click **Report a vulnerability**.
-4. Submit details privately.
+1. Open the private vulnerability report form:
+   <https://github.com/swimmwatch/cloakbrowser-mcp/security/advisories/new>.
+2. Or open the repository on GitHub, go to the **Security** tab, and click
+   **Report a vulnerability**.
+3. Submit details privately.
 
 Do **not** open public issues for vulnerabilities.
 

--- a/docs/.meta.yml
+++ b/docs/.meta.yml
@@ -1,0 +1,1 @@
+image: assets/brand/social-card.png

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ The generated [CLI Reference](generated/cli.md) is the authoritative list of bri
 | `CLOAK_PLAYWRIGHT_MCP_TRANSPORT` | `stdio` | Bridge transport: `stdio` or `streamable-http`. |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_HOST` | `127.0.0.1` | Streamable HTTP bind host. |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_PORT` | `3000` | Streamable HTTP bind port. Use `0` for an ephemeral port in tests. |
-| `CLOAK_PLAYWRIGHT_MCP_HTTP_ENDPOINT` | `/mcp` | Streamable HTTP endpoint path. |
+| `CLOAK_PLAYWRIGHT_MCP_HTTP_ENDPOINT` | `/mcp` | Streamable HTTP endpoint path. `/healthz` and `/readyz` are reserved for probes. |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_AUTH_TOKEN` | unset | Optional Bearer token required on Streamable HTTP requests. |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_SESSION_BACKEND` | `memory` | Session metadata backend. Only `memory` is implemented in this release. |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_SESSION_IDLE_TTL_MS` | `3600000` | Idle TTL for Streamable HTTP sessions. Expired sessions dispose their bridge and upstream child process. |
@@ -58,3 +58,13 @@ Refer to the upstream Playwright MCP documentation for the full upstream option 
 Each Streamable HTTP MCP session owns its own bridge runtime and upstream Playwright MCP child process. HTTP sessions run upstream Playwright MCP with an isolated browser profile so concurrent users do not contend for the same persistent Chromium profile. The built-in `memory` session backend stores only metadata such as session ID, timestamps, expiry, and status. Browser state remains in the live upstream child process, and artifacts are still controlled by `PLAYWRIGHT_MCP_OUTPUT_DIR`.
 
 For horizontal scaling, run multiple server replicas behind a load balancer with sticky sessions keyed by the `mcp-session-id` header. Future Redis, Postgres, or SQLite backends can coordinate metadata and locks, but they cannot restore a live browser session after the process that owns it exits.
+
+## Streamable HTTP Probes
+
+When the bridge runs with `--transport streamable-http`, it exposes fixed probe endpoints on the same host and port as the MCP endpoint:
+
+- `GET /healthz` returns process health metadata: `status`, `version`, `transport`, and `uptimeMs`.
+- `GET /readyz` returns readiness metadata and session capacity: `sessions.active`, `sessions.pending`, `sessions.max`, and `sessions.available`.
+
+Readiness returns HTTP `200` while session capacity is available and HTTP `503` when `active + pending >= max`.
+If `--http-auth-token` or `CLOAK_PLAYWRIGHT_MCP_HTTP_AUTH_TOKEN` is configured, both probes require the same `Authorization: Bearer ...` header as MCP requests. Without an auth token, the probes are open on the configured HTTP bind address.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,9 +33,13 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
   -v "$PWD/artifacts:/data" \
   swimmwatch/cloakbrowser-mcp:latest \
   --transport streamable-http --http-host 0.0.0.0 --http-port 3000
+
+curl http://127.0.0.1:3000/healthz
+curl http://127.0.0.1:3000/readyz
 ```
 
 The host-side `127.0.0.1:3000` bind keeps the endpoint local. If you publish Streamable HTTP on a non-loopback interface, put it behind authentication, TLS, and network controls.
+Streamable HTTP exposes fixed `GET /healthz` and `GET /readyz` probes on the same host and port. If `--http-auth-token` or `CLOAK_PLAYWRIGHT_MCP_HTTP_AUTH_TOKEN` is configured, the probes require the same `Authorization: Bearer ...` header as MCP requests.
 See the generated [CLI Reference](generated/cli.md) for all HTTP transport flags and environment variables.
 
 ## Defaults
@@ -50,6 +54,7 @@ See the generated [CLI Reference](generated/cli.md) for all HTTP transport flags
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_HOST` | `127.0.0.1` |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_PORT` | `3000` |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_ENDPOINT` | `/mcp` |
+| `CLOAK_PLAYWRIGHT_MCP_HTTP_AUTH_TOKEN` | unset |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_SESSION_BACKEND` | `memory` |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_SESSION_IDLE_TTL_MS` | `3600000` |
 | `CLOAK_PLAYWRIGHT_MCP_HTTP_SESSION_MAX` | `32` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,6 +17,8 @@ For a quick overview of common setup questions, see the [FAQ](faq.md).
 
 ```bash
 npx -y cloakbrowser-mcp@latest --help
+npx -y cloakbrowser-mcp@latest doctor
+npx -y cloakbrowser-mcp@latest doctor --json
 npx -y cloakbrowser-mcp@latest
 npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 ```
@@ -29,7 +31,9 @@ npx -y cloakbrowser-mcp@1.2.7
 
 The npm package requires Node.js 20 or newer. CloakBrowser downloads its Chromium binary on first use unless it is already cached.
 
-The default transport is stdio. Use `--transport streamable-http` when your MCP client connects to an HTTP endpoint instead of spawning a stdio process. The HTTP endpoint defaults to `http://127.0.0.1:3000/mcp`.
+Use `doctor` to verify the local Node.js runtime, package metadata, upstream Playwright MCP CLI resolution, and CloakBrowser binary metadata before connecting a client. The command does not start the bridge or download a browser.
+
+The default transport is stdio. Use `--transport streamable-http` when your MCP client connects to an HTTP endpoint instead of spawning a stdio process. The HTTP endpoint defaults to `http://127.0.0.1:3000/mcp`, with fixed `GET /healthz` and `GET /readyz` probes on the same host and port.
 See the generated [CLI Reference](generated/cli.md) for the full flag list and matching environment variables.
 
 ## Docker
@@ -51,6 +55,9 @@ docker run --rm --init -p 127.0.0.1:3000:3000 \
   -v "$PWD/artifacts:/data" \
   swimmwatch/cloakbrowser-mcp:latest \
   --transport streamable-http --http-host 0.0.0.0 --http-port 3000
+
+curl http://127.0.0.1:3000/healthz
+curl http://127.0.0.1:3000/readyz
 ```
 
 Pin a release when reproducibility matters:
@@ -66,6 +73,7 @@ docker run --rm --init -i \
 
 Most MCP clients use the same stdio shape: `command`, optional `args`, and optional `env`.
 For Streamable HTTP clients, start the server separately and configure the client URL as `http://127.0.0.1:3000/mcp`.
+If `CLOAK_PLAYWRIGHT_MCP_HTTP_AUTH_TOKEN` or `--http-auth-token` is set, send the same Bearer token to `/mcp`, `/healthz`, and `/readyz`.
 
 ### npm Config
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,3 +24,9 @@ Upstream Playwright MCP browser tools are forwarded unchanged. CloakBrowser MCP 
 
 - cloakbrowser_binary_info
 - cloakbrowser_bridge_info
+
+## Diagnostics
+
+- CLI diagnostics: `cloakbrowser-mcp doctor` or `cloakbrowser-mcp doctor --json`
+- Streamable HTTP probes: `GET /healthz` and `GET /readyz`
+- Probe authorization: when `--http-auth-token` is configured, probes require the same Bearer token as MCP requests.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,10 +5,8 @@
   {% set seo = config.extra.seo or {} %}
   {% set verification = seo.verification or {} %}
   {% set raw_page_title = page.meta.title if page.meta and page.meta.title else page.title | striptags %}
-  {% set seo_title = raw_page_title if page.is_homepage else raw_page_title ~ " - " ~ config.site_name %}
   {% set seo_description = page.meta.description if page.meta and page.meta.description else config.site_description %}
   {% set canonical_url = page.canonical_url or config.site_url %}
-  {% set social_image = config.site_url ~ seo.image %}
 
   <link rel="apple-touch-icon" sizes="180x180" href="{{ 'assets/brand/apple-touch-icon.png' | url }}" />
   <link rel="manifest" href="{{ 'site.webmanifest' | url }}" />
@@ -31,20 +29,6 @@
   {% if verification.naver %}
     <meta name="naver-site-verification" content="{{ verification.naver }}" />
   {% endif %}
-
-  <meta property="og:site_name" content="{{ config.site_name }}" />
-  <meta property="og:title" content="{{ seo_title }}" />
-  <meta property="og:description" content="{{ seo_description }}" />
-  <meta property="og:type" content="{{ 'website' if page.is_homepage else 'article' }}" />
-  <meta property="og:url" content="{{ canonical_url }}" />
-  <meta property="og:image" content="{{ social_image }}" />
-  <meta property="og:image:alt" content="CloakBrowser MCP social preview card" />
-  <meta property="og:locale" content="en_US" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="{{ seo_title }}" />
-  <meta name="twitter:description" content="{{ seo_description }}" />
-  <meta name="twitter:image" content="{{ social_image }}" />
-  <meta name="twitter:image:alt" content="CloakBrowser MCP social preview card" />
 
   <script type="application/ld+json">
     {{

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs-material[imaging]>=9.7.6
-mkdocs-git-revision-date-localized-plugin>=1.2.4
-mkdocs-minify-plugin>=0.7.1
+mkdocs-git-revision-date-localized-plugin>=1.5.3
+mkdocs-minify-plugin>=0.8.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs-material[imaging]>=9.7.6
+mkdocs-advanced-seo>=1.0.3
 mkdocs-git-revision-date-localized-plugin>=1.5.3
 mkdocs-minify-plugin>=0.8.0

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -14,6 +14,8 @@ tags:
 
 The default upstream browser tool surface is expected to match the pinned Playwright MCP dependency. This includes the core browser tools such as navigation, snapshot, click, typing, screenshots, tabs, console messages, network inspection, file upload, dialogs, and unsafe evaluation tools.
 
+For a stable upstream reference, see the Playwright MCP `@playwright/mcp@0.0.75` capability test pinned to the exact package commit: [default and capability-gated tool names](https://github.com/microsoft/playwright-mcp/blob/8116437ffcfee1309cebc07dd30cee37720d2d19/tests/capabilities.spec.ts#L19-L77).
+
 This project treats upstream Playwright MCP as authoritative and does not maintain a copied schema reference.
 
 ## Local Tools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,17 @@ plugins:
         logo: docs/assets/brand/logo.svg
         background_color: '#0f766e'
         color: '#ffffff'
+  - advanced-seo:
+      url_base: https://swimmwatch.github.io/cloakbrowser-mcp/
+      use_canonical_url: false
+      use_open_graph: true
+      use_twitter_cards: true
+      add_schema_org_json_ld: true
+      og_type: website
+      og_image: assets/brand/social-card.png
+      og_locale: en_US
+      twitter_card_type: summary_large_image
+      support_document_dates: true
   - minify:
       minify_html: !ENV [MKDOCS_MINIFY_HTML, true]
       htmlmin_opts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.2",
         "@vitest/coverage-v8": "^4.1.8",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1248,9 +1248,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2036,9 +2036,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2332,9 +2332,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2556,10 +2556,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2664,9 +2663,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2676,9 +2675,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3296,20 +3295,6 @@
         "fsevents": "2.3.2"
       }
     },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/playwright/node_modules/playwright-core": {
       "version": "1.61.0-alpha-1778188671000",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1778188671000.tgz",
@@ -3516,9 +3501,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3726,9 +3711,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -3759,9 +3744,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3824,6 +3809,21 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/type-check": {
@@ -4502,6 +4502,21 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
@@ -4663,9 +4678,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ajv-formats": "^3.0.1",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.8.0",
         "prettier": "^3.8.3",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
@@ -2411,6 +2412,29 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3384,6 +3408,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,14 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.9.2",
         "@vitest/coverage-v8": "^4.1.8",
-        "ajv": "^8.17.1",
+        "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
-        "prettier": "^3.3.3",
-        "tsx": "^4.19.0",
+        "prettier": "^3.8.3",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.11.0",
+        "typescript-eslint": "^8.60.1",
         "vitest": "^4.1.8"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.9.1",
+    "@types/node": "^25.9.2",
     "@vitest/coverage-v8": "^4.1.8",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -71,14 +71,14 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.2",
     "@vitest/coverage-v8": "^4.1.8",
-    "ajv": "^8.17.1",
+    "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
-    "prettier": "^3.3.3",
-    "tsx": "^4.19.0",
+    "prettier": "^3.8.3",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.11.0",
+    "typescript-eslint": "^8.60.1",
     "vitest": "^4.1.8"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ajv-formats": "^3.0.1",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.8.0",
     "prettier": "^3.8.3",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/scripts/lib/playwright-mcp-upstream.mjs
+++ b/scripts/lib/playwright-mcp-upstream.mjs
@@ -91,7 +91,7 @@ export function createReleaseNotesSummary(releases) {
 
 function extractDockerImageVersion(dockerfile) {
   const match = dockerfile.match(
-    /^ARG PLAYWRIGHT_MCP_IMAGE=mcr\.microsoft\.com\/playwright\/mcp:(?<tag>\S+)$/m,
+    /^ARG PLAYWRIGHT_MCP_IMAGE=mcr\.microsoft\.com\/playwright\/mcp:(?<tag>[^@\s]+)(?:@sha256:[a-f0-9]{64})?$/m,
   );
 
   if (!match?.groups?.tag) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
+import { createDoctorReport, renderDoctorReport } from './cli/doctor.js';
 import { createCliCommand, readCliOptions } from './cli/options.js';
 import { startStreamableHttpBridge } from './http/server.js';
 import { PROJECT_METADATA } from './project/metadata.js';
@@ -12,7 +13,15 @@ const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url),
 };
 
 async function main(): Promise<void> {
-  const command = createCliCommand(pkg.version);
+  const command = createCliCommand(pkg.version, {
+    doctorAction: (options) => {
+      const report = createDoctorReport();
+      process.stdout.write(
+        options.json ? `${JSON.stringify(report, null, 2)}\n` : renderDoctorReport(report),
+      );
+      if (report.status === 'error') process.exitCode = 1;
+    },
+  });
   command.action(async () => {
     const options = readCliOptions(command);
     const serverInfo = {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,184 @@
+import { existsSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+import { getCurrentCloakBinaryInfo } from '../bridge/config.js';
+import { resolvePlaywrightMcpCliPath } from '../bridge/paths.js';
+import { PLAYWRIGHT_MCP_PACKAGE, PLAYWRIGHT_MCP_VERSION, PROJECT_METADATA } from '../project/metadata.js';
+
+export type DoctorStatus = 'ok' | 'warning' | 'error';
+
+export interface DoctorCheck {
+  name: string;
+  status: DoctorStatus;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface DoctorReport {
+  status: DoctorStatus;
+  project: {
+    packageName: string;
+    mcpName: string;
+    version: string;
+    nodeEngine: string;
+  };
+  node: {
+    version: string;
+    supported: boolean;
+  };
+  upstream: {
+    package: string;
+    version: string;
+    cliPath: string | null;
+  };
+  cloakbrowser: ReturnType<typeof getCurrentCloakBinaryInfo> | null;
+  checks: DoctorCheck[];
+}
+
+interface PackageMetadata {
+  engines?: {
+    node?: string;
+  };
+}
+
+const packageMetadata = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+) as PackageMetadata;
+
+export function createDoctorReport(): DoctorReport {
+  const checks: DoctorCheck[] = [];
+  const nodeEngine = packageMetadata.engines?.node ?? 'unknown';
+  const nodeSupported = isNodeVersionSupported(process.versions.node, nodeEngine);
+  checks.push({
+    name: 'node',
+    status: nodeSupported ? 'ok' : 'error',
+    message: nodeSupported
+      ? `Node.js ${process.version} satisfies ${nodeEngine}`
+      : `Node.js ${process.version} does not satisfy ${nodeEngine}`,
+    details: {
+      version: process.version,
+      required: nodeEngine,
+    },
+  });
+
+  let playwrightMcpCliPath: string | null = null;
+  try {
+    playwrightMcpCliPath = resolvePlaywrightMcpCliPath();
+    checks.push({
+      name: 'playwright-mcp-cli',
+      status: existsSync(playwrightMcpCliPath) ? 'ok' : 'error',
+      message: existsSync(playwrightMcpCliPath)
+        ? `Resolved ${PLAYWRIGHT_MCP_PACKAGE} CLI`
+        : `Resolved ${PLAYWRIGHT_MCP_PACKAGE} CLI path does not exist`,
+      details: {
+        package: PLAYWRIGHT_MCP_PACKAGE,
+        version: PLAYWRIGHT_MCP_VERSION,
+        cliPath: playwrightMcpCliPath,
+      },
+    });
+  } catch (error) {
+    checks.push({
+      name: 'playwright-mcp-cli',
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Failed to resolve Playwright MCP CLI',
+    });
+  }
+
+  let cloakbrowser: ReturnType<typeof getCurrentCloakBinaryInfo> | null = null;
+  try {
+    cloakbrowser = getCurrentCloakBinaryInfo();
+    checks.push({
+      name: 'cloakbrowser-binary',
+      status: cloakbrowser.installed ? 'ok' : 'warning',
+      message: cloakbrowser.installed
+        ? 'CloakBrowser binary is installed'
+        : 'CloakBrowser binary is not installed; the first browser action may download it',
+      details: {
+        version: cloakbrowser.version,
+        platform: cloakbrowser.platform,
+        binaryPath: cloakbrowser.binaryPath,
+        cacheDir: cloakbrowser.cacheDir,
+        installed: cloakbrowser.installed,
+      },
+    });
+  } catch (error) {
+    checks.push({
+      name: 'cloakbrowser-binary',
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Failed to read CloakBrowser binary metadata',
+    });
+  }
+
+  return {
+    status: summarizeStatus(checks),
+    project: {
+      packageName: PROJECT_METADATA.packageName,
+      mcpName: PROJECT_METADATA.mcpName,
+      version: PROJECT_METADATA.version,
+      nodeEngine,
+    },
+    node: {
+      version: process.version,
+      supported: nodeSupported,
+    },
+    upstream: {
+      package: PLAYWRIGHT_MCP_PACKAGE,
+      version: PLAYWRIGHT_MCP_VERSION,
+      cliPath: playwrightMcpCliPath,
+    },
+    cloakbrowser,
+    checks,
+  };
+}
+
+export function renderDoctorReport(report: DoctorReport): string {
+  return [
+    'CloakBrowser MCP doctor',
+    `Status: ${report.status}`,
+    `Project: ${report.project.packageName} ${report.project.version} (${report.project.mcpName})`,
+    `Node.js: ${report.node.version} (requires ${report.project.nodeEngine})`,
+    `Upstream: ${report.upstream.package} ${report.upstream.version}`,
+    `Upstream CLI: ${report.upstream.cliPath ?? 'unresolved'}`,
+    `CloakBrowser: ${formatCloakbrowserSummary(report)}`,
+    '',
+    'Checks:',
+    ...report.checks.map((check) => `- [${check.status}] ${check.name}: ${check.message}`),
+    '',
+  ].join('\n');
+}
+
+function formatCloakbrowserSummary(report: DoctorReport): string {
+  if (!report.cloakbrowser) return 'unavailable';
+  const installed = report.cloakbrowser.installed ? 'installed' : 'not installed';
+  return `${report.cloakbrowser.version} (${report.cloakbrowser.platform}, ${installed})`;
+}
+
+function summarizeStatus(checks: readonly DoctorCheck[]): DoctorStatus {
+  if (checks.some((check) => check.status === 'error')) return 'error';
+  if (checks.some((check) => check.status === 'warning')) return 'warning';
+  return 'ok';
+}
+
+function isNodeVersionSupported(version: string, range: string): boolean {
+  const minimum = parseMinimumNodeVersion(range);
+  if (!minimum) return true;
+  return compareVersions(parseVersion(version), minimum) >= 0;
+}
+
+function parseMinimumNodeVersion(range: string): [number, number, number] | undefined {
+  const match = /^>=\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(range);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
+}
+
+function parseVersion(version: string): [number, number, number] {
+  const [major = '0', minor = '0', patch = '0'] = version.replace(/^v/, '').split('.');
+  return [Number(major), Number(minor), Number(patch)];
+}
+
+function compareVersions(actual: [number, number, number], expected: [number, number, number]): number {
+  for (const index of [0, 1, 2] as const) {
+    const difference = actual[index] - expected[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -44,6 +44,23 @@ const packageMetadata = JSON.parse(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
 ) as PackageMetadata;
 
+const doctorReportTemplate = `CloakBrowser MCP doctor
+Status: {{status}}
+Project: {{project}}
+Node.js: {{node}}
+Upstream: {{upstream}}
+Upstream CLI: {{upstreamCli}}
+CloakBrowser: {{cloakbrowser}}
+
+Checks:
+{{checks}}
+`;
+
+type DoctorReportTemplateValues = Record<
+  'status' | 'project' | 'node' | 'upstream' | 'upstreamCli' | 'cloakbrowser' | 'checks',
+  string
+>;
+
 export function createDoctorReport(): DoctorReport {
   const checks: DoctorCheck[] = [];
   const nodeEngine = packageMetadata.engines?.node ?? 'unknown';
@@ -131,25 +148,29 @@ export function createDoctorReport(): DoctorReport {
 }
 
 export function renderDoctorReport(report: DoctorReport): string {
-  return [
-    'CloakBrowser MCP doctor',
-    `Status: ${report.status}`,
-    `Project: ${report.project.packageName} ${report.project.version} (${report.project.mcpName})`,
-    `Node.js: ${report.node.version} (requires ${report.project.nodeEngine})`,
-    `Upstream: ${report.upstream.package} ${report.upstream.version}`,
-    `Upstream CLI: ${report.upstream.cliPath ?? 'unresolved'}`,
-    `CloakBrowser: ${formatCloakbrowserSummary(report)}`,
-    '',
-    'Checks:',
-    ...report.checks.map((check) => `- [${check.status}] ${check.name}: ${check.message}`),
-    '',
-  ].join('\n');
+  return formatDoctorReportTemplate({
+    status: report.status,
+    project: `${report.project.packageName} ${report.project.version} (${report.project.mcpName})`,
+    node: `${report.node.version} (requires ${report.project.nodeEngine})`,
+    upstream: `${report.upstream.package} ${report.upstream.version}`,
+    upstreamCli: report.upstream.cliPath ?? 'unresolved',
+    cloakbrowser: formatCloakbrowserSummary(report),
+    checks: report.checks.map((check) => `- [${check.status}] ${check.name}: ${check.message}`).join('\n'),
+  });
 }
 
 function formatCloakbrowserSummary(report: DoctorReport): string {
   if (!report.cloakbrowser) return 'unavailable';
   const installed = report.cloakbrowser.installed ? 'installed' : 'not installed';
   return `${report.cloakbrowser.version} (${report.cloakbrowser.platform}, ${installed})`;
+}
+
+function formatDoctorReportTemplate(values: DoctorReportTemplateValues): string {
+  let output = doctorReportTemplate;
+  for (const [key, value] of Object.entries(values)) {
+    output = output.replaceAll(`{{${key}}}`, value);
+  }
+  return output;
 }
 
 function summarizeStatus(checks: readonly DoctorCheck[]): DoctorStatus {

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -21,6 +21,14 @@ interface CommanderCliOptions {
   httpSessionMax: number;
 }
 
+interface DoctorCliOptions {
+  json?: boolean;
+}
+
+interface CreateCliCommandOptions {
+  doctorAction?: (options: DoctorCliOptions) => Promise<void> | void;
+}
+
 type CliOptionValue = string | number;
 
 interface CliOptionDefinition {
@@ -65,7 +73,7 @@ export const cliOptionDefinitions: readonly CliOptionDefinition[] = [
   {
     name: 'httpEndpoint',
     flags: '--http-endpoint <path>',
-    description: 'Streamable HTTP endpoint path.',
+    description: 'Streamable HTTP endpoint path. Reserved probe paths: /healthz, /readyz.',
     env: 'CLOAK_PLAYWRIGHT_MCP_HTTP_ENDPOINT',
     group: 'Streamable HTTP',
     defaultValue: defaultStreamableHttpOptions.endpoint,
@@ -108,18 +116,21 @@ export const cliOptionDefinitions: readonly CliOptionDefinition[] = [
   },
 ];
 
-export function createCliCommand(version: string): Command {
+export function createCliCommand(version: string, options: CreateCliCommandOptions = {}): Command {
   const command = new Command()
     .name('cloakbrowser-mcp')
     .description(cliDescription)
     .version(version)
     .showHelpAfterError()
     .showSuggestionAfterError()
-    .allowExcessArguments(false);
+    .allowExcessArguments(false)
+    .action(() => undefined);
 
   for (const definition of cliOptionDefinitions) {
     command.addOption(createCommanderOption(definition));
   }
+
+  command.addCommand(createDoctorCommand(options.doctorAction));
 
   return command;
 }
@@ -151,10 +162,32 @@ This page is generated from the Commander.js CLI definition during MkDocs builds
 ${command.helpInformation().trimEnd()}
 \`\`\`
 
+## Commands
+
+### \`doctor\`
+
+\`\`\`text
+${createDoctorCommand().helpInformation().trimEnd()}
+\`\`\`
+
 ## Options
 
 ${renderOptionsTable()}
 `;
+}
+
+function createDoctorCommand(action?: (options: DoctorCliOptions) => Promise<void> | void): Command {
+  const command = new Command('doctor')
+    .description('Run local diagnostics without starting the MCP bridge.')
+    .option('--json', 'Output diagnostics as JSON.');
+
+  if (action) {
+    command.action(async (options: DoctorCliOptions) => {
+      await action(options);
+    });
+  }
+
+  return command;
 }
 
 function createCommanderOption(definition: CliOptionDefinition): Option {
@@ -258,6 +291,9 @@ function parseInteger(label: string, value: string): number {
 function parseHttpEndpoint(value: string): string {
   if (!value.startsWith('/') || value.includes('?') || value.includes('#')) {
     throw new InvalidArgumentError('HTTP endpoint must be an absolute path such as "/mcp"');
+  }
+  if (value === '/healthz' || value === '/readyz') {
+    throw new InvalidArgumentError('HTTP endpoint must not use reserved probe paths "/healthz" or "/readyz"');
   }
   if (value.length > 1 && value.endsWith('/')) {
     throw new InvalidArgumentError('HTTP endpoint must not end with "/"');

--- a/src/http/options.ts
+++ b/src/http/options.ts
@@ -6,6 +6,7 @@ export const bridgeTransportModes = [
   'streamable-http',
 ] as const satisfies readonly BridgeTransportMode[];
 export const httpSessionBackends = ['memory'] as const satisfies readonly HttpSessionBackend[];
+export const streamableHttpProbePaths = ['/healthz', '/readyz'] as const;
 
 export interface StreamableHttpOptions {
   host: string;

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -10,8 +10,7 @@ import { HttpStatus, JsonRpcErrorCode } from './status.js';
 
 const mcpSessionIdHeader = 'mcp-session-id';
 const jsonRpcContentType = 'application/json';
-const healthzPath = streamableHttpProbePaths[0];
-const readyzPath = streamableHttpProbePaths[1];
+const [healthzPath, readyzPath] = streamableHttpProbePaths;
 const allowedMethods = 'GET, POST, DELETE';
 
 export interface StartStreamableHttpBridgeOptions extends StreamableHttpOptions {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -5,11 +5,13 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { isInitializeRequest, type Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { createBridgeServer, type BridgeServer } from '../server.js';
 import { createSessionStore, type HttpSessionRecord, type SessionStore } from './sessionStore.js';
-import type { HttpSessionBackend, StreamableHttpOptions } from './options.js';
+import { streamableHttpProbePaths, type HttpSessionBackend, type StreamableHttpOptions } from './options.js';
 import { HttpStatus, JsonRpcErrorCode } from './status.js';
 
 const mcpSessionIdHeader = 'mcp-session-id';
 const jsonRpcContentType = 'application/json';
+const healthzPath = streamableHttpProbePaths[0];
+const readyzPath = streamableHttpProbePaths[1];
 const allowedMethods = 'GET, POST, DELETE';
 
 export interface StartStreamableHttpBridgeOptions extends StreamableHttpOptions {
@@ -61,6 +63,7 @@ class StreamableHttpBridgeController {
   readonly #closing = new Map<string, Promise<void>>();
   readonly #httpServer: Server;
   readonly #cleanupTimer: NodeJS.Timeout;
+  readonly #startedAt = Date.now();
   #pendingSessionInitializations = 0;
 
   constructor(options: StartStreamableHttpBridgeOptions) {
@@ -98,6 +101,16 @@ class StreamableHttpBridgeController {
 
   async #handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
+      if (isEndpointRequest(req, healthzPath, this.#options.host)) {
+        this.#handleHealthProbe(req, res);
+        return;
+      }
+
+      if (isEndpointRequest(req, readyzPath, this.#options.host)) {
+        await this.#handleReadinessProbe(req, res);
+        return;
+      }
+
       if (!isEndpointRequest(req, this.#options.endpoint, this.#options.host)) {
         writeJsonRpcError(res, HttpStatus.NotFound, JsonRpcErrorCode.ServerError, 'Not found');
         return;
@@ -317,6 +330,63 @@ class StreamableHttpBridgeController {
     if (!session) return;
     await session.bridge.dispose();
   }
+
+  #handleHealthProbe(req: IncomingMessage, res: ServerResponse): void {
+    if (!this.#authorizeProbeRequest(req, res)) return;
+    if (req.method !== 'GET') {
+      writeJsonResponse(res, HttpStatus.MethodNotAllowed, { status: 'method_not_allowed' }, { Allow: 'GET' });
+      return;
+    }
+
+    writeJsonResponse(res, HttpStatus.Ok, {
+      status: 'ok',
+      version: this.#options.serverInfo?.version ?? 'unknown',
+      transport: 'streamable-http',
+      uptimeMs: this.#uptimeMs(),
+    });
+  }
+
+  async #handleReadinessProbe(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!this.#authorizeProbeRequest(req, res)) return;
+    if (req.method !== 'GET') {
+      writeJsonResponse(res, HttpStatus.MethodNotAllowed, { status: 'method_not_allowed' }, { Allow: 'GET' });
+      return;
+    }
+
+    await this.#closeExpiredSessions();
+    const active = this.#sessions.size;
+    const pending = this.#pendingSessionInitializations;
+    const max = this.#options.sessionMax;
+    const available = Math.max(max - active - pending, 0);
+    const ready = available > 0;
+    writeJsonResponse(res, ready ? HttpStatus.Ok : HttpStatus.ServiceUnavailable, {
+      status: ready ? 'ready' : 'not_ready',
+      version: this.#options.serverInfo?.version ?? 'unknown',
+      transport: 'streamable-http',
+      uptimeMs: this.#uptimeMs(),
+      sessions: {
+        active,
+        pending,
+        max,
+        available,
+      },
+    });
+  }
+
+  #authorizeProbeRequest(req: IncomingMessage, res: ServerResponse): boolean {
+    if (isAuthorizedRequest(req, this.#options.authToken)) return true;
+    writeJsonResponse(
+      res,
+      HttpStatus.Unauthorized,
+      { status: 'unauthorized' },
+      { 'WWW-Authenticate': 'Bearer' },
+    );
+    return false;
+  }
+
+  #uptimeMs(): number {
+    return Math.max(Date.now() - this.#startedAt, 0);
+  }
 }
 
 function hasJsonContentType(req: IncomingMessage): boolean {
@@ -374,6 +444,19 @@ function writeJsonRpcError(
       id: null,
     }),
   );
+}
+
+function writeJsonResponse(
+  res: ServerResponse,
+  status: HttpStatus,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): void {
+  res.writeHead(status, {
+    'Content-Type': jsonRpcContentType,
+    ...headers,
+  });
+  res.end(JSON.stringify(body));
 }
 
 function formatHost(host: string): string {

--- a/tests/integration/streamable-http.test.ts
+++ b/tests/integration/streamable-http.test.ts
@@ -119,6 +119,33 @@ describe('streamable HTTP bridge', () => {
     });
   });
 
+  it('reports readiness based on active HTTP session capacity', async () => {
+    await withFakeUpstream(async () => {
+      const server = await startHttpBridge({ sessionMax: 1 });
+
+      const initial = await fetch(new URL('/readyz', server.url));
+      expect(initial.status).toBe(HttpStatus.Ok);
+
+      await connectHttpClient(server);
+
+      const full = await fetch(new URL('/readyz', server.url));
+      const body = (await full.json()) as {
+        status: string;
+        sessions: { active: number; pending: number; max: number; available: number };
+      };
+      expect(full.status).toBe(HttpStatus.ServiceUnavailable);
+      expect(body).toMatchObject({
+        status: 'not_ready',
+        sessions: {
+          active: 1,
+          pending: 0,
+          max: 1,
+          available: 0,
+        },
+      });
+    });
+  });
+
   it('enforces optional Bearer auth before handling MCP requests', async () => {
     await withFakeUpstream(async () => {
       const server = await startHttpBridge({ authToken: 'secret' });

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createDoctorReport, renderDoctorReport } from '../../src/cli/doctor.js';
+
+describe('CLI doctor diagnostics', () => {
+  it('returns a stable diagnostics report without starting the bridge', () => {
+    const report = createDoctorReport();
+
+    expect(['ok', 'warning']).toContain(report.status);
+    expect(report.project).toMatchObject({
+      packageName: 'cloakbrowser-mcp',
+      mcpName: 'io.github.swimmwatch/cloakbrowser-mcp',
+      nodeEngine: '>=20.0.0',
+    });
+    expect(report.node.supported).toBe(true);
+    expect(report.upstream.package).toBe('@playwright/mcp');
+    expect(report.upstream.cliPath).toEqual(expect.stringContaining('@playwright/mcp'));
+    expect(report.checks.map((check) => check.name)).toEqual([
+      'node',
+      'playwright-mcp-cli',
+      'cloakbrowser-binary',
+    ]);
+  });
+
+  it('renders human-readable diagnostics', () => {
+    const output = renderDoctorReport(createDoctorReport());
+
+    expect(output).toContain('CloakBrowser MCP doctor');
+    expect(output).toContain('Checks:');
+    expect(output).toContain('playwright-mcp-cli');
+  });
+});

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createDoctorReport, renderDoctorReport } from '../../src/cli/doctor.js';
 
 describe('CLI doctor diagnostics', () => {
+  afterEach(() => {
+    vi.doUnmock('../../src/bridge/config.js');
+    vi.doUnmock('../../src/bridge/paths.js');
+    vi.resetModules();
+  });
+
   it('returns a stable diagnostics report without starting the bridge', () => {
     const report = createDoctorReport();
 
@@ -27,5 +34,70 @@ describe('CLI doctor diagnostics', () => {
     expect(output).toContain('CloakBrowser MCP doctor');
     expect(output).toContain('Checks:');
     expect(output).toContain('playwright-mcp-cli');
+  });
+
+  it('reports a warning when CloakBrowser metadata exists but the binary is not installed', async () => {
+    const playwrightCliPath = fileURLToPath(
+      new URL('../../node_modules/@playwright/mcp/cli.js', import.meta.url),
+    );
+    vi.doMock('../../src/bridge/paths.js', () => ({
+      resolvePlaywrightMcpCliPath: () => playwrightCliPath,
+    }));
+    vi.doMock('../../src/bridge/config.js', () => ({
+      getCurrentCloakBinaryInfo: () => ({
+        version: '146.0.0',
+        platform: 'linux-x64',
+        binaryPath: '/cache/chrome',
+        installed: false,
+        cacheDir: '/cache',
+        downloadUrl: 'https://example.invalid/cloakbrowser.tar.gz',
+      }),
+    }));
+
+    const doctor = await import('../../src/cli/doctor.js');
+    const report = doctor.createDoctorReport();
+
+    expect(report.status).toBe('warning');
+    expect(report.cloakbrowser?.installed).toBe(false);
+    expect(report.checks.find((check) => check.name === 'cloakbrowser-binary')).toMatchObject({
+      status: 'warning',
+      message: expect.stringContaining('not installed'),
+    });
+    expect(doctor.renderDoctorReport(report)).toContain('not installed');
+  });
+
+  it('reports hard failures when required upstream and CloakBrowser metadata cannot be resolved', async () => {
+    vi.doMock('../../src/bridge/paths.js', () => ({
+      resolvePlaywrightMcpCliPath: () => {
+        throw new Error('missing upstream cli');
+      },
+    }));
+    vi.doMock('../../src/bridge/config.js', () => ({
+      getCurrentCloakBinaryInfo: () => {
+        throw new Error('missing cloak metadata');
+      },
+    }));
+
+    const doctor = await import('../../src/cli/doctor.js');
+    const report = doctor.createDoctorReport();
+
+    expect(report.status).toBe('error');
+    expect(report.upstream.cliPath).toBeNull();
+    expect(report.cloakbrowser).toBeNull();
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'playwright-mcp-cli',
+          status: 'error',
+          message: 'missing upstream cli',
+        }),
+        expect.objectContaining({
+          name: 'cloakbrowser-binary',
+          status: 'error',
+          message: 'missing cloak metadata',
+        }),
+      ]),
+    );
+    expect(doctor.renderDoctorReport(report)).toContain('CloakBrowser: unavailable');
   });
 });

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import { appendNodeOption, envBool, envInt, envList, envString } from '../../src/bridge/env.js';
 
@@ -25,6 +26,29 @@ describe('bridge environment helpers', () => {
     expect(appendNodeOption(undefined, '--require=/tmp/a.cjs')).toBe('--require=/tmp/a.cjs');
     expect(appendNodeOption('--enable-source-maps', '--require=/tmp/a.cjs')).toBe(
       '--enable-source-maps --require=/tmp/a.cjs',
+    );
+  });
+
+  it('round-trips JSON string arrays for list environment values', () => {
+    fc.assert(
+      fc.property(fc.array(fc.string({ maxLength: 24 }), { maxLength: 12 }), (values) => {
+        expect(envList({ JSON_LIST: JSON.stringify(values) }, 'JSON_LIST')).toEqual(values);
+      }),
+    );
+  });
+
+  it('preserves appended Node.js options after an existing option string', () => {
+    const token = fc
+      .array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/_:=-.'), {
+        minLength: 1,
+        maxLength: 24,
+      })
+      .map((chars) => chars.join(''));
+
+    fc.assert(
+      fc.property(token, token, (existing, next) => {
+        expect(appendNodeOption(existing, next)).toBe(`${existing} ${next}`);
+      }),
     );
   });
 });

--- a/tests/unit/http-options.test.ts
+++ b/tests/unit/http-options.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import {
   cliOptionDefinitions,
@@ -90,6 +91,37 @@ describe('Commander CLI options', () => {
       expect(() => parseCliOptions(['--http-session-idle-ttl-ms', '0'])).toThrow('idle TTL');
       expect(() => parseCliOptions(['--http-session-max', '0'])).toThrow('session max');
     });
+  });
+
+  it('accepts valid HTTP ports from CLI flags across the full port range', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 65_535 }), (port) => {
+        withCliEnv({}, () => {
+          expect(parseCliOptions(['--http-port', String(port)]).http.port).toBe(port);
+        });
+      }),
+    );
+  });
+
+  it('accepts valid absolute HTTP endpoint paths', () => {
+    const segment = fc
+      .array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._~-'), {
+        minLength: 1,
+        maxLength: 12,
+      })
+      .map((chars) => chars.join(''));
+    const endpoint = fc
+      .array(segment, { minLength: 1, maxLength: 4 })
+      .map((segments) => `/${segments.join('/')}`)
+      .filter((value) => value !== '/healthz' && value !== '/readyz');
+
+    fc.assert(
+      fc.property(endpoint, (value) => {
+        withCliEnv({}, () => {
+          expect(parseCliOptions(['--http-endpoint', value]).http.endpoint).toBe(value);
+        });
+      }),
+    );
   });
 
   it('wires the doctor subcommand and JSON flag', async () => {

--- a/tests/unit/http-options.test.ts
+++ b/tests/unit/http-options.test.ts
@@ -71,12 +71,22 @@ describe('Commander CLI options', () => {
 
   it('validates HTTP bounds', () => {
     withCliEnv({}, () => {
+      expect(() => parseCliOptions(['--http-port', 'abc'])).toThrow('HTTP port must be an integer');
+      expect(() => parseCliOptions(['--http-port', '9007199254740992'])).toThrow(
+        'HTTP port must be a safe integer',
+      );
       expect(() => parseCliOptions(['--transport', 'streamable-http', '--http-port', '70000'])).toThrow(
         'HTTP port',
       );
       expect(() => parseCliOptions(['--http-endpoint', 'mcp'])).toThrow('HTTP endpoint');
+      expect(() => parseCliOptions(['--http-endpoint', '/mcp?debug=1'])).toThrow('HTTP endpoint');
+      expect(() => parseCliOptions(['--http-endpoint', '/mcp#debug'])).toThrow('HTTP endpoint');
+      expect(() => parseCliOptions(['--http-endpoint', '/mcp/'])).toThrow('must not end with "/"');
       expect(() => parseCliOptions(['--http-endpoint', '/healthz'])).toThrow('reserved probe paths');
       expect(() => parseCliOptions(['--http-endpoint', '/readyz'])).toThrow('reserved probe paths');
+      expect(() => parseCliOptions(['--http-auth-token', '   '])).toThrow(
+        'HTTP auth token must not be empty',
+      );
       expect(() => parseCliOptions(['--http-session-idle-ttl-ms', '0'])).toThrow('idle TTL');
       expect(() => parseCliOptions(['--http-session-max', '0'])).toThrow('session max');
     });

--- a/tests/unit/http-options.test.ts
+++ b/tests/unit/http-options.test.ts
@@ -75,9 +75,33 @@ describe('Commander CLI options', () => {
         'HTTP port',
       );
       expect(() => parseCliOptions(['--http-endpoint', 'mcp'])).toThrow('HTTP endpoint');
+      expect(() => parseCliOptions(['--http-endpoint', '/healthz'])).toThrow('reserved probe paths');
+      expect(() => parseCliOptions(['--http-endpoint', '/readyz'])).toThrow('reserved probe paths');
       expect(() => parseCliOptions(['--http-session-idle-ttl-ms', '0'])).toThrow('idle TTL');
       expect(() => parseCliOptions(['--http-session-max', '0'])).toThrow('session max');
     });
+  });
+
+  it('wires the doctor subcommand and JSON flag', async () => {
+    let doctorJson = false;
+    const command = createCliCommand('1.2.3', {
+      doctorAction: (options) => {
+        doctorJson = options.json === true;
+      },
+    });
+    command.exitOverride();
+    command.configureOutput({
+      writeOut: () => undefined,
+      writeErr: () => undefined,
+    });
+
+    await command.parseAsync(['doctor', '--json'], { from: 'user' });
+
+    expect(doctorJson).toBe(true);
+    expect(command.helpInformation()).toContain('doctor');
+    expect(
+      command.commands.find((subcommand) => subcommand.name() === 'doctor')?.helpInformation(),
+    ).toContain('--json');
   });
 
   it('generates Commander help and Markdown reference from the option metadata', () => {
@@ -86,9 +110,12 @@ describe('Commander CLI options', () => {
 
     expect(help).toContain('Playwright MCP bridge backed by CloakBrowser');
     expect(help).toContain('--transport <mode>');
+    expect(help).toContain('doctor');
     expect(help).toContain('--http-session-max <count>');
     expect(help).toContain('CLOAK_PLAYWRIGHT_MCP_HTTP_SESSION_MAX');
     expect(reference).toContain('# CLI Reference');
+    expect(reference).toContain('### `doctor`');
+    expect(reference).toContain('--json');
     expect(reference).toContain('| `--http-auth-token <token>` |');
     expect(reference).toContain('`streamable-http`');
   });

--- a/tests/unit/http-server.test.ts
+++ b/tests/unit/http-server.test.ts
@@ -101,6 +101,34 @@ describe('HTTP server helpers', () => {
     }
   });
 
+  it('serves probe JSON with default version metadata and rejects non-GET probe methods', async () => {
+    const server = await startStreamableHttpBridge({
+      ...defaultStreamableHttpOptions,
+      port: 0,
+    });
+
+    try {
+      const health = await fetch(new URL('/healthz?probe=1', server.url));
+      const healthBody = (await health.json()) as Record<string, unknown>;
+      expect(health.status).toBe(HttpStatus.Ok);
+      expect(healthBody).toMatchObject({
+        status: 'ok',
+        version: 'unknown',
+        transport: 'streamable-http',
+      });
+
+      for (const path of ['/healthz', '/readyz']) {
+        const methodNotAllowed = await fetch(new URL(path, server.url), { method: 'POST' });
+        const methodNotAllowedBody = (await methodNotAllowed.json()) as Record<string, unknown>;
+        expect(methodNotAllowed.status).toBe(HttpStatus.MethodNotAllowed);
+        expect(methodNotAllowed.headers.get('allow')).toBe('GET');
+        expect(methodNotAllowedBody).toEqual({ status: 'method_not_allowed' });
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it('protects probes with the configured Bearer token', async () => {
     const server = await startStreamableHttpBridge({
       ...defaultStreamableHttpOptions,
@@ -110,8 +138,10 @@ describe('HTTP server helpers', () => {
 
     try {
       const unauthorized = await fetch(new URL('/healthz', server.url));
+      const unauthorizedBody = (await unauthorized.json()) as Record<string, unknown>;
       expect(unauthorized.status).toBe(HttpStatus.Unauthorized);
       expect(unauthorized.headers.get('www-authenticate')).toBe('Bearer');
+      expect(unauthorizedBody).toEqual({ status: 'unauthorized' });
 
       const authorized = await fetch(new URL('/readyz', server.url), {
         headers: { Authorization: 'Bearer secret' },

--- a/tests/unit/http-server.test.ts
+++ b/tests/unit/http-server.test.ts
@@ -63,6 +63,65 @@ describe('HTTP server helpers', () => {
     }
   });
 
+  it('serves unauthenticated health and readiness probes when no auth token is configured', async () => {
+    const server = await startStreamableHttpBridge({
+      ...defaultStreamableHttpOptions,
+      port: 0,
+      serverInfo: { version: '1.2.3' },
+    });
+
+    try {
+      const health = await fetch(new URL('/healthz', server.url));
+      const healthBody = (await health.json()) as Record<string, unknown>;
+      expect(health.status).toBe(HttpStatus.Ok);
+      expect(healthBody).toMatchObject({
+        status: 'ok',
+        version: '1.2.3',
+        transport: 'streamable-http',
+      });
+      expect(healthBody.uptimeMs).toEqual(expect.any(Number));
+
+      const ready = await fetch(new URL('/readyz', server.url));
+      const readyBody = (await ready.json()) as {
+        status: string;
+        sessions: { active: number; pending: number; max: number; available: number };
+      };
+      expect(ready.status).toBe(HttpStatus.Ok);
+      expect(readyBody).toMatchObject({
+        status: 'ready',
+        sessions: {
+          active: 0,
+          pending: 0,
+          max: defaultStreamableHttpOptions.sessionMax,
+          available: defaultStreamableHttpOptions.sessionMax,
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('protects probes with the configured Bearer token', async () => {
+    const server = await startStreamableHttpBridge({
+      ...defaultStreamableHttpOptions,
+      port: 0,
+      authToken: 'secret',
+    });
+
+    try {
+      const unauthorized = await fetch(new URL('/healthz', server.url));
+      expect(unauthorized.status).toBe(HttpStatus.Unauthorized);
+      expect(unauthorized.headers.get('www-authenticate')).toBe('Bearer');
+
+      const authorized = await fetch(new URL('/readyz', server.url), {
+        headers: { Authorization: 'Bearer secret' },
+      });
+      expect(authorized.status).toBe(HttpStatus.Ok);
+    } finally {
+      await server.close();
+    }
+  });
+
   it('exports named HTTP and JSON-RPC response codes used by server responses', () => {
     expect(HttpStatus.BadRequest).toBe(400);
     expect(HttpStatus.Unauthorized).toBe(401);


### PR DESCRIPTION
## Summary

- Added fixed Streamable HTTP `GET /healthz` and `GET /readyz` probes for process health and session-capacity readiness.
- Added `cloakbrowser-mcp doctor [--json]` diagnostics for Node.js, package metadata, upstream Playwright MCP CLI resolution, and CloakBrowser binary metadata.
- Reserved `/healthz` and `/readyz`, expanded edge-case tests for the new behavior, and raised coverage for the changed modules.
- Expanded Node.js workflow check coverage to explicitly run major versions `20`, `21`, `22`, `23`, `24`, `25`, and `26`.
- Added Dependabot tracking for MkDocs Python dependencies in `docs/requirements.txt` and updated compatible npm/Python dependencies.

## Checklist

- [x] I ran `npm run check` locally and it passed.
- [x] If I changed public behavior, I updated `README.md` and relevant docs in `docs/`.
- [x] If I changed local bridge tools, I updated `docs/tools.md`. Not applicable: no local MCP tools were added, removed, or changed.
- [x] If I changed bridge configuration, I updated `docs/configuration.md`.
- [x] Upstream Playwright MCP tool schemas, descriptions, and responses are not copied or mutated.
- [x] I added/updated tests (unit and/or integration as appropriate).
- [x] I added an entry to `CHANGELOG.md` under `## [Unreleased]`.
- [x] I reviewed security implications and documented them below.

## Security review

Streamable HTTP probes are served by the bridge controller outside the MCP endpoint and do not mutate upstream Playwright MCP tool schemas, descriptions, or responses. When `--http-auth-token` or `CLOAK_PLAYWRIGHT_MCP_HTTP_AUTH_TOKEN` is configured, `/healthz` and `/readyz` require the same `Authorization: Bearer ...` header as MCP requests; without a token they are open only on the configured HTTP bind address. Probe responses expose status, version, transport, uptime, and session counts only, with no secrets or token values.

The `doctor` command is diagnostics-only: it reads local package metadata, resolves the upstream CLI path, and reports existing CloakBrowser binary metadata without starting the MCP bridge, launching upstream child processes, or downloading a browser. It writes only the requested human or JSON diagnostics to stdout and does not add runtime logging. Filesystem access is limited to metadata/path inspection. Docker behavior is unchanged except documented probe usage; there are no registry publishing, OIDC, or secret-handling workflow changes.

The CI/release matrix change broadens check coverage only. Release publishing jobs still run once and wait for the new matrix gate, so npm publication, Docker registry publishing, OIDC, and secrets/tokens are not multiplied across Node versions.

The Dependabot update adds monitoring for public Python documentation dependencies under `/docs`; it does not add private registries, credentials, registry publishing, OIDC, or new secret usage. The npm/Python dependency updates do not change bridge child-process, filesystem, Docker runtime, logging, or token handling behavior.

## Test evidence

- `npm run test:unit -- tests/unit/doctor.test.ts tests/unit/http-server.test.ts tests/unit/http-options.test.ts` passed: 9 files, 33 tests.
- `npm run test:coverage` passed: 11 files, 43 tests; coverage increased to 90.27% statements, 81.25% branches, and 93.10% lines before the dependency update.
- `npm run check` passed after the dependency update: typecheck, lint, format check, server.json validation, build, and 43 Vitest tests.
- `npm run check:ci` passed after the dependency update: `npm run check`, production audit with 0 vulnerabilities, and coverage run at 90.36% statements, 81.25% branches, and 93.17% lines.
- `npm run package:verify` passed and verified `cloakbrowser-mcp-1.2.7.tgz`.
- `npm run docs:install` passed and installed the updated MkDocs requirements.
- `npm run docs:build` passed in strict mode. MkDocs Material emitted its upstream MkDocs 2.0 warning, but the command exited successfully.
- `npm run docs:seo:validate` passed.
- `python3` parsed `.github/dependabot.yml` and confirmed the `pip` `/docs` entry is present.
- `node dist/cli.js doctor --json` passed with status `ok`.
- `node dist/cli.js doctor` passed with status `ok`.
- `npm run docker:build` passed and built `cloakbrowser-mcp:dev`.
- `npm run docker:smoke` passed and showed the new `doctor` command in container help.
- `npm run bridge:compare -- cloakbrowser-mcp:dev --report bridge-parity-report.json` passed for 23 upstream Playwright MCP tools; the generated report was removed afterward.
- `docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12 -color` passed with no output after the workflow matrix changes.
- `python3 -m pipx run zizmor --min-severity high .` passed with no findings after the workflow matrix changes.
- `git diff --check` passed.
