### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-06
+
 ### Added
 
 - Added a project release skill for AI agents to prepare, publish, verify, and
@@ -157,7 +159,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generated configuration documentation based on the removed native config schema.
 - Public SEO setup guide and stale roadmap page from the published documentation.
 
-[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.7...HEAD
+[Unreleased]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.7...v1.3.0
 [1.2.7]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/swimmwatch/cloakbrowser-mcp/compare/v1.2.3...v1.2.5

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The server is intentionally thin:
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base | CloakBrowser | Node.js | Transport | Platform | Parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.3.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.31` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.7` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.6` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |
 | `1.2.5` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | `linux/amd64` Docker, Node.js local | Upstream default tools compared in CI. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ npx -y cloakbrowser-mcp@latest --transport streamable-http --http-port 3000
 Pin a release when reproducibility matters:
 
 ```bash
-npx -y cloakbrowser-mcp@1.2.7
+npx -y cloakbrowser-mcp@1.3.0
 ```
 
 The npm package requires Node.js 20 or newer. CloakBrowser downloads its Chromium binary on first use unless it is already cached.
@@ -63,10 +63,10 @@ curl http://127.0.0.1:3000/readyz
 Pin a release when reproducibility matters:
 
 ```bash
-docker pull swimmwatch/cloakbrowser-mcp:1.2.7
+docker pull swimmwatch/cloakbrowser-mcp:1.3.0
 docker run --rm --init -i \
   -v "$PWD/artifacts:/data" \
-  swimmwatch/cloakbrowser-mcp:1.2.7
+  swimmwatch/cloakbrowser-mcp:1.3.0
 ```
 
 ## MCP Client Config

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,13 @@ tags:
 
 `cloakbrowser-mcp` is a Model Context Protocol browser automation server that runs upstream `@playwright/mcp` with the CloakBrowser Chromium binary. Use it when you want Playwright MCP-compatible browser tools, CloakBrowser execution, npm installation, or a Docker image for stdio and Streamable HTTP MCP clients.
 
-Current version: <!-- project-version -->v1.2.7<!-- /project-version -->.
+Current version: <!-- project-version -->v1.3.0<!-- /project-version -->.
 
 ## Version Compatibility
 
 | cloakbrowser-mcp | @playwright/mcp | Playwright MCP Docker base                 | CloakBrowser | Transport              | Parity         |
 | ---------------- | --------------- | ------------------------------------------ | ------------ | ---------------------- | -------------- |
+| `1.3.0`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.31`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.7`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.6`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |
 | `1.2.5`          | `^0.0.75`       | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30`    | stdio, Streamable HTTP | Compared in CI |

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -13,6 +13,7 @@ Playwright MCP version it is built and tested against.
 
 | cloakbrowser-mcp | @playwright/mcp dependency | Playwright MCP Docker base | CloakBrowser dependency | Node.js | Transport | Tested platform | Tool parity |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1.3.0` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.31` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20-26, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.7` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.6` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |
 | `1.2.5` | `^0.0.75` | `mcr.microsoft.com/playwright/mcp:v0.0.75` | `^0.3.30` | `>=20` | stdio, Streamable HTTP | npm on Node.js 20/22, Docker `linux/amd64` | Upstream default browser tools compared against the official Playwright MCP image in CI. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser-mcp",
-      "version": "1.2.7",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloakbrowser-mcp",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "Playwright MCP-compatible browser automation bridge for CloakBrowser Chromium.",
   "mcpName": "io.github.swimmwatch/cloakbrowser-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.swimmwatch/cloakbrowser-mcp",
   "title": "CloakBrowser MCP",
   "description": "Playwright MCP-compatible browser automation bridge for CloakBrowser Chromium.",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "websiteUrl": "https://swimmwatch.github.io/cloakbrowser-mcp/",
   "repository": {
     "url": "https://github.com/swimmwatch/cloakbrowser-mcp",
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.7",
+      "version": "1.3.0",
       "transport": {
         "type": "stdio"
       },
@@ -67,7 +67,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "cloakbrowser-mcp",
-      "version": "1.2.7",
+      "version": "1.3.0",
       "packageArguments": [
         {
           "type": "named",
@@ -161,7 +161,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.2.7",
+      "identifier": "ghcr.io/swimmwatch/cloakbrowser-mcp:1.3.0",
       "transport": {
         "type": "stdio"
       },
@@ -205,7 +205,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/swimmwatch/cloakbrowser-mcp:1.2.7",
+      "identifier": "docker.io/swimmwatch/cloakbrowser-mcp:1.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Prepares the stable `v1.3.0` release after the HTTP probes, doctor command, docs, dependency, and security hardening changes merged to `main`.
- Updates package metadata, `server.json`, pinned install examples, compatibility tables, and changelog links for `1.3.0`.
- Keeps upstream Playwright MCP contracts unchanged and records the CloakBrowser dependency used by this release.

## Checklist

- [x] I ran `npm run check` locally and it passed via `npm run check:ci`.
- [x] If I changed public behavior, I updated `README.md` and relevant docs in `docs/`.
- [x] If I changed local bridge tools, I updated `docs/tools.md`. N/A for this release-prep commit; tool docs were updated in the merged feature PR.
- [x] If I changed bridge configuration, I updated `docs/configuration.md`. N/A for this release-prep commit; configuration docs were updated in the merged feature PR.
- [x] Upstream Playwright MCP tool schemas, descriptions, and responses are not copied or mutated.
- [x] I added/updated tests (unit and/or integration as appropriate). N/A for release metadata; feature and hardening tests were merged before this release prep.
- [x] I added an entry to `CHANGELOG.md` under `## [Unreleased]`. Release prep moved current entries into `## [1.3.0] - 2026-06-06` and reset `[Unreleased]`.
- [x] I reviewed security implications and documented them below.

## Security review

This PR is release metadata only. It does not change bridge runtime behavior, child-process spawning, filesystem access, Dockerfile instructions, runtime logging, secrets, tokens, OIDC configuration, or registry publishing workflow logic.

The resulting GitHub Release will trigger the existing release workflow, which publishes npm, GHCR, Docker Hub, docs, and MCP Registry artifacts using the repository's configured release permissions and secrets. No new secret names or token scopes are introduced here.

## Test evidence

Passed locally:

- `npm run check:ci`
- `npm run package:verify`
- `npm run docker:build`
- `npm run docker:smoke`
- `npm run bridge:compare -- cloakbrowser-mcp:dev --report bridge-parity-report.json`
- `docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color`
- `python3 -m pipx run zizmor --min-severity high .`
- `npm run docs:build`
- `npm run docs:seo:validate`

`bridge-parity-report.json` was inspected through command output and removed after the parity check completed.
