### PR TITLE
fix: auto-clean stale Chromium SingletonLock on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Auto-cleanup of stale Chromium `SingletonLock` files on stdio startup to prevent
+  "Browser is already in use" errors after an unclean shutdown (SIGKILL/crash).
+
 ## [1.4.0] - 2026-06-21
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,11 +106,14 @@ function cleanStaleSingletonLocks(): void {
     const pidMatch = /\d+$/.exec(target);
     if (!pidMatch) continue;
     const pid = Number(pidMatch[0]);
+    if (!Number.isSafeInteger(pid) || pid <= 0) continue;
     // kill(pid, 0) does NOT send a signal — it only checks existence.
     try {
       process.kill(pid, 0);
       continue; // process alive — skip
-    } catch {
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== 'ESRCH') continue; // EPERM or unexpected error — don't delete locks
       // process dead — clean all lock files
     }
     for (const f of ['SingletonLock', 'SingletonCookie', 'SingletonSocket'] as const) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, readlinkSync, unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import process from 'node:process';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { createDoctorReport, renderDoctorReport } from '#src/cli/doctor';
@@ -50,6 +52,7 @@ async function main(): Promise<void> {
 }
 
 async function startStdioBridge(serverInfo: Partial<Implementation>): Promise<{ close(): Promise<void> }> {
+  cleanStaleSingletonLocks();
   const bridge = await startBridge({ serverInfo });
   return {
     close: () => bridge.dispose(),
@@ -66,6 +69,58 @@ async function startStreamableHttpCliBridge(
   });
   logger.info({ url: bridge.url }, 'streamable-http listening');
   return bridge;
+}
+
+/**
+ * Clean stale Chromium SingletonLock files left behind by killed browser
+ * processes. Chromium uses these symlinks to prevent concurrent profile
+ * access — when the browser is killed with SIGKILL, the lock files remain and
+ * block every subsequent launch with "Browser is already in use".
+ *
+ * This runs on every CloakBrowser MCP stdio startup, before the Playwright
+ * MCP subprocess is spawned, so the downstream process never sees a zombie.
+ *
+ * Related upstream issues (fixed in newer @playwright/mcp but not in the
+ * version that ships with CloakBrowser):
+ * - microsoft/playwright-mcp#1311
+ * - microsoft/playwright-mcp#1305
+ * - microsoft/playwright-mcp#1245
+ */
+function cleanStaleSingletonLocks(): void {
+  const cacheDir = join(homedir(), '.cache', 'ms-playwright-mcp');
+  let entries: string[];
+  try {
+    entries = readdirSync(cacheDir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.startsWith('mcp-chromium-')) continue;
+    const lockPath = join(cacheDir, entry, 'SingletonLock');
+    let target: string;
+    try {
+      target = readlinkSync(lockPath);
+    } catch {
+      continue;
+    }
+    const pidMatch = /\d+$/.exec(target);
+    if (!pidMatch) continue;
+    const pid = Number(pidMatch[0]);
+    // kill(pid, 0) does NOT send a signal — it only checks existence.
+    try {
+      process.kill(pid, 0);
+      continue; // process alive — skip
+    } catch {
+      // process dead — clean all lock files
+    }
+    for (const f of ['SingletonLock', 'SingletonCookie', 'SingletonSocket'] as const) {
+      try {
+        unlinkSync(join(cacheDir, entry, f));
+      } catch {
+        // ignore — file may not exist
+      }
+    }
+  }
 }
 
 void main().catch((error: unknown) => {


### PR DESCRIPTION
## Problem

When the CloakBrowser (Chromium) process is killed with `SIGKILL` or crashes, the `SingletonLock` symlink in `~/.cache/ms-playwright-mcp/mcp-chromium-*/` persists. On the next startup, Playwright MCP sees the lock and throws:

```
Browser is already in use for /home/<user>/.cache/ms-playwright-mcp/mcp-chromium-989279d
```

Because CloakBrowser MCP uses a persistent `userDataDir` (not `--isolated`), this makes the MCP server permanently unusable until the lock files are manually deleted. In practice, multiple agent retries stack up orphaned `cloakbrowser-mcp` processes — all blocked by the same zombie lock.

## Root Cause

This is Chromium-level behavior — the `SingletonLock` file is managed by the browser process. Neither Playwright MCP nor CloakBrowser MCP implements stale lock detection. Upstream fixes exist in newer `@playwright/mcp` releases (microsoft/playwright-mcp#1311, #1305, #1245) but are not in the version CloakBrowser bundles.

## Fix

Added `cleanStaleSingletonLocks()` in `src/cli.ts`, called at the top of `startStdioBridge()` — before the Playwright MCP subprocess is spawned:

1. Scan `~/.cache/ms-playwright-mcp/mcp-chromium-*/` for `SingletonLock` symlinks
2. Extract PID from the symlink target (e.g., `Wen-200100` → PID `200100`)
3. `kill(pid, 0)` to check if the process is alive
4. If dead → remove all three lock files: `SingletonLock`, `SingletonCookie`, `SingletonSocket`

## Testing

- All existing tests pass (`npm run check` — 64 unit + 6 e2e)
- Manually verified: create fake zombie lock → CloakBrowser MCP starts → lock cleaned → browser navigates successfully

## Checklist

- [x] `npm run check` passes
- [x] No upstream Playwright MCP tool contracts modified
- [x] `CHANGELOG.md` updated
- [x] Zero-cost on happy path (returns early if dir doesn't exist or no locks found)