### PR TITLE
fix(ci): resolve MCP schema update source

### DIFF
--- a/.github/actions/check-mcp-schema-updates/action.yml
+++ b/.github/actions/check-mcp-schema-updates/action.yml
@@ -1,0 +1,189 @@
+name: Check MCP Schema Updates
+description: Check whether the latest upstream MCP JSON schema differs from the stored snapshot.
+
+inputs:
+  schema-dir:
+    description: Directory containing latest.json and dated MCP schema snapshots.
+    required: false
+    default: schemas/mcp
+  schema-source-url:
+    description: Explicit MCP schema URL to check. When omitted, schema-catalog-url discovery is used.
+    required: false
+    default: ''
+  schema-catalog-url:
+    description: JSON catalog URL used to discover the latest dated MCP schema version.
+    required: false
+    default: https://api.github.com/repos/modelcontextprotocol/static/contents/schemas?ref=main
+  checked-at:
+    description: ISO date recorded by the check. Defaults to the current UTC date.
+    required: false
+    default: ''
+  write-snapshots:
+    description: Whether to write latest.json and a dated snapshot when a schema change is detected.
+    required: false
+    default: 'false'
+  emit-notice:
+    description: Whether to emit a GitHub Actions notice when a schema update is available.
+    required: false
+    default: 'true'
+  write-step-summary:
+    description: Whether to append the check result to the GitHub Actions step summary.
+    required: false
+    default: 'true'
+  change-message:
+    description: Human-readable message used when a schema update is available.
+    required: false
+    default: MCP schema update available.
+  no-change-message:
+    description: Human-readable message used when no schema update is available.
+    required: false
+    default: No MCP schema changes detected.
+
+outputs:
+  changed:
+    description: Whether the latest upstream schema differs from the stored snapshot.
+    value: ${{ steps.check.outputs.changed }}
+  schema_source_url:
+    description: MCP schema URL used for the check.
+    value: ${{ steps.check.outputs.schema_source_url }}
+  checked_at:
+    description: ISO date recorded by the check.
+    value: ${{ steps.check.outputs.checked_at }}
+  latest_schema_path:
+    description: Path to the stored latest schema snapshot.
+    value: ${{ steps.check.outputs.latest_schema_path }}
+  snapshot_path:
+    description: Path written for the dated schema snapshot, when write-snapshots is true and a change is detected.
+    value: ${{ steps.check.outputs.snapshot_path }}
+  previous_schema_path:
+    description: Path to the previous stored schema snapshot.
+    value: ${{ steps.check.outputs.previous_schema_path }}
+  diff_summary:
+    description: Short summary of detected schema differences.
+    value: ${{ steps.check.outputs.diff_summary }}
+  snapshots_written:
+    description: Whether this run wrote latest.json and a dated schema snapshot.
+    value: ${{ steps.check.outputs.snapshots_written }}
+
+runs:
+  using: composite
+  steps:
+    - id: validate-inputs
+      name: Validate inputs
+      shell: bash
+      env:
+        EMIT_NOTICE: ${{ inputs.emit-notice }}
+        WRITE_SNAPSHOTS: ${{ inputs.write-snapshots }}
+        WRITE_STEP_SUMMARY: ${{ inputs.write-step-summary }}
+      run: |
+        set -euo pipefail
+
+        for name in EMIT_NOTICE WRITE_SNAPSHOTS WRITE_STEP_SUMMARY
+        do
+          case "${!name}" in
+            true|false) ;;
+            *)
+              echo "::error title=Invalid action input::$name must be true or false"
+              exit 1
+              ;;
+          esac
+        done
+
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: '22'
+        package-manager-cache: false
+
+    - id: check
+      name: Check MCP schema updates
+      shell: bash
+      env:
+        INPUT_CHECKED_AT: ${{ inputs.checked-at }}
+        INPUT_SCHEMA_CATALOG_URL: ${{ inputs.schema-catalog-url }}
+        INPUT_SCHEMA_DIR: ${{ inputs.schema-dir }}
+        INPUT_SCHEMA_SOURCE_URL: ${{ inputs.schema-source-url }}
+        INPUT_WRITE_SNAPSHOTS: ${{ inputs.write-snapshots }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "$INPUT_CHECKED_AT" ]; then
+          export MCP_SCHEMA_CHECKED_AT="$INPUT_CHECKED_AT"
+        fi
+
+        if [ -n "$INPUT_SCHEMA_CATALOG_URL" ]; then
+          export MCP_SCHEMA_CATALOG_URL="$INPUT_SCHEMA_CATALOG_URL"
+        fi
+
+        if [ -n "$INPUT_SCHEMA_DIR" ]; then
+          export MCP_SCHEMA_DIR="$INPUT_SCHEMA_DIR"
+        fi
+
+        if [ -n "$INPUT_SCHEMA_SOURCE_URL" ]; then
+          export MCP_SCHEMA_SOURCE_URL="$INPUT_SCHEMA_SOURCE_URL"
+        fi
+
+        export MCP_SCHEMA_WRITE_SNAPSHOTS="$INPUT_WRITE_SNAPSHOTS"
+
+        node scripts/check-mcp-schema-updates.mjs
+
+    - name: Report schema check result
+      shell: bash
+      env:
+        CHANGE_MESSAGE: ${{ inputs.change-message }}
+        CHECKED_AT: ${{ steps.check.outputs.checked_at }}
+        CHANGED: ${{ steps.check.outputs.changed }}
+        DIFF_SUMMARY: ${{ steps.check.outputs.diff_summary }}
+        EMIT_NOTICE: ${{ inputs.emit-notice }}
+        LATEST_SCHEMA_PATH: ${{ steps.check.outputs.latest_schema_path }}
+        NO_CHANGE_MESSAGE: ${{ inputs.no-change-message }}
+        PREVIOUS_SCHEMA_PATH: ${{ steps.check.outputs.previous_schema_path }}
+        SCHEMA_SOURCE_URL: ${{ steps.check.outputs.schema_source_url }}
+        SNAPSHOT_PATH: ${{ steps.check.outputs.snapshot_path }}
+        SNAPSHOTS_WRITTEN: ${{ steps.check.outputs.snapshots_written }}
+        WRITE_STEP_SUMMARY: ${{ inputs.write-step-summary }}
+      run: |
+        set -euo pipefail
+
+        escape_command() {
+          local value="$1"
+          value="${value//'%'/'%25'}"
+          value="${value//$'\r'/'%0D'}"
+          value="${value//$'\n'/'%0A'}"
+          printf '%s' "$value"
+        }
+
+        markdown_cell() {
+          local value="$1"
+          value="${value//$'\r'/' '}"
+          value="${value//$'\n'/' '}"
+          value="${value//'|'/'\|'}"
+          printf '%s' "$value"
+        }
+
+        if [ "$CHANGED" = "true" ]; then
+          message="$CHANGE_MESSAGE Source: $SCHEMA_SOURCE_URL. Diff: $DIFF_SUMMARY"
+          echo "$message"
+          if [ "$EMIT_NOTICE" = "true" ]; then
+            echo "::notice title=MCP schema update available::$(escape_command "$message")"
+          fi
+        else
+          echo "$NO_CHANGE_MESSAGE"
+        fi
+
+        if [ "$WRITE_STEP_SUMMARY" = "true" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          {
+            echo "### MCP Schema Update Check"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Changed | $(markdown_cell "${CHANGED:-false}") |"
+            echo "| Schema source | $(markdown_cell "${SCHEMA_SOURCE_URL:-}") |"
+            echo "| Checked at | $(markdown_cell "${CHECKED_AT:-}") |"
+            echo "| Latest schema path | $(markdown_cell "${LATEST_SCHEMA_PATH:-}") |"
+            echo "| Previous schema path | $(markdown_cell "${PREVIOUS_SCHEMA_PATH:-}") |"
+            echo "| Snapshot path | $(markdown_cell "${SNAPSHOT_PATH:-}") |"
+            echo "| Snapshots written | $(markdown_cell "${SNAPSHOTS_WRITTEN:-false}") |"
+            echo "| Diff summary | $(markdown_cell "${DIFF_SUMMARY:-}") |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/workflows/update-mcp-schema.yml
+++ b/.github/workflows/update-mcp-schema.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  MCP_SCHEMA_DIR: schemas/mcp
+
 permissions:
   contents: read
 
@@ -22,18 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: '22'
-          package-manager-cache: false
-
       - id: schema
         name: Check MCP schema updates
-        run: node scripts/check-mcp-schema-updates.mjs
-
-      - name: Report no schema change
-        if: steps.schema.outputs.changed != 'true'
-        run: echo 'No MCP schema changes detected.'
+        uses: ./.github/actions/check-mcp-schema-updates
+        with:
+          schema-dir: ${{ env.MCP_SCHEMA_DIR }}
+          write-snapshots: true
 
       - id: pull-request
         if: steps.schema.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@
 
 ## 30-second demo
 
-<video controls preload="metadata" poster="docs/assets/videos/30-second-demo-poster.png" aria-label="30-second demo showing CloakBrowser MCP startup, humanized research prompt typing, web automation, and testing workflows">
-<source src="docs/assets/videos/30-second-demo.mp4" type="video/mp4">
-</video>
+[![30-second demo showing CloakBrowser MCP startup, humanized research prompt typing, web automation, and testing workflows](docs/assets/videos/30-second-demo.webp)](docs/assets/videos/30-second-demo.mp4)
 
 Run `npx -y cloakbrowser-mcp@latest`, connect Claude Desktop or Codex CLI, ask for web research, daily automation, or testing in plain English, and inspect the real browser result.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@
 
 ## 30-second demo
 
-[![30-second demo showing CloakBrowser MCP startup, humanized research prompt typing, web automation, and testing workflows](docs/assets/videos/30-second-demo.webp)](docs/assets/videos/30-second-demo.mp4)
+<video controls preload="metadata" poster="docs/assets/videos/30-second-demo-poster.png" aria-label="30-second demo showing CloakBrowser MCP startup, humanized research prompt typing, web automation, and testing workflows">
+<source src="docs/assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 
 Run `npx -y cloakbrowser-mcp@latest`, connect Claude Desktop or Codex CLI, ask for web research, daily automation, or testing in plain English, and inspect the real browser result.
 

--- a/docs/data/translation-manifest.json
+++ b/docs/data/translation-manifest.json
@@ -795,75 +795,75 @@
       }
     },
     "index.md": {
-      "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
+      "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
       "translations": {
         "ru": {
           "path": "index.ru.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "ab999433199de8f1557c1a5cf687b983fad2aa74885e3beeafba3ad2ae6a79e0",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "d7545f8dbc96862dda7444680fff9f1df22921e9c3667019d3328097d147f6f1",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "be": {
           "path": "index.be.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "402edeef71521f9757df4794b16d50c67bb74b6f087876379d8cd4c62a2c2973",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "f447cc72c5087f9f2e4b61ad0968097fb63d92f0e859f9aaacd0dcb0c0b495b6",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "uk": {
           "path": "index.uk.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "8bd77dbf038ae7f161712471dc42c3cce845ec343721217e48f423bc25688a58",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "3e14461921f44cb59f3bdc0e806681781b02b3b7e975bb0db5a349d402ffddb6",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "es": {
           "path": "index.es.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "e9b19977d3a7b8f7ed839777e707da24fb9def77fd3fd380e3b3a1e436373954",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "a5600ce3c80a07c4929017e64df64da43207d14dcf6370fa6b1383374be7a55d",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "pt-BR": {
           "path": "index.pt-BR.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "93e03e2d71a81692bc28c6fd0c962d488fbf762a2076407095b4b62b37f517aa",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "338bafa24dbb47520daae2cca8092e40f8eb606536ee2b4e67dc0eb96b20aacc",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "zh": {
           "path": "index.zh.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "341b914d7a41e4a3b10551b22c17f0fb396bc7266436edda00cf4b46c4a0673b",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "e99060185c85323c9c03e43c9fac50b0ad23da7a4d57112cb3fdad7d34b02dc4",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "ja": {
           "path": "index.ja.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "1b01b65049e480677b4c6cef6cd0ffe300ad82cf7e3d71059edec7b946364e5d",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "c035849f421b2ab1ca7176389db97398f898fd66b08ae342ec95b3f4e5b89afb",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "de": {
           "path": "index.de.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "5a85ac84b7b8ce1a27ad6049bc78baf9e2f678565a118313258ded322a1dd891",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "3c4588fe6568ed945d55003d2df0138a4f4514e77ca7680f17b9ed3389a46489",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "fr": {
           "path": "index.fr.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "14d93cd636d08a9a48d0acd203dd59d8dc30540ee5664e7aea8a3792935e1fdc",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "aa21092646837fba0d631d8b381d24ec497ec92d2344fee2e44ac94e026f734a",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         },
         "hi": {
           "path": "index.hi.md",
-          "sourceHash": "22ef7a0f07e0c8eb864c832cfc0251e231d0fc4d3deac290ba9c14a633ed48d8",
-          "translationHash": "b5ffb7319e17ec6202aa7f4a20cd6f7a7179e98f730ebe26390ede8382c6574d",
+          "sourceHash": "71838ab6d54534a79c0f8a607935bbcd807af4a3b9aa2672155021e242704cc9",
+          "translationHash": "0850ba4b9c4ca224cf0e3a3cf1774ae26366a7c5634dc55ace7e775a7a969a95",
           "translator": "manual targeted translation",
           "updatedAt": "2026-07-07T14:48:42.179Z"
         }

--- a/docs/index.be.md
+++ b/docs/index.be.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30-секундная дэманстрацыя
 
-<div class="clb-demo-video" markdown>
-[![30-секундная дэманстрацыя CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="30-секундная дэманстрацыя CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Паглядзіце першы запуск: запусціце npm-пакет, падключыце MCP-кліент, папрасіце выканаць вэб-даследаванне, аўтаматызацыю або тэставанне і праверце вынік у сапраўдным браўзеры.</p>

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30-Sekunden-Demo
 
-<div class="clb-demo-video" markdown>
-[![30-Sekunden-Demo von CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="30-Sekunden-Demo von CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Sehen Sie den ersten Lauf: Starten Sie das npm-Paket, verbinden Sie einen MCP-Client, bitten Sie um Web-Recherche, Automatisierung oder Tests und prüfen Sie das Ergebnis im echten Browser.</p>

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -21,8 +21,10 @@ tags:
 
 ## Demo de 30 segundos
 
-<div class="clb-demo-video" markdown>
-[![Demo de 30 segundos de CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="Demo de 30 segundos de CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Mira el primer arranque: inicia el paquete npm, conecta un cliente MCP, pide investigación web, automatización o pruebas, e inspecciona el resultado en un navegador real.</p>

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -21,8 +21,10 @@ tags:
 
 ## Démo de 30 secondes
 
-<div class="clb-demo-video" markdown>
-[![Démo de 30 secondes de CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="Démo de 30 secondes de CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Regardez le premier lancement : démarrez le paquet npm, connectez un client MCP, demandez une recherche web, une automatisation ou des tests, puis inspectez le résultat dans un vrai navigateur.</p>

--- a/docs/index.hi.md
+++ b/docs/index.hi.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30-सेकंड का डेमो
 
-<div class="clb-demo-video" markdown>
-[![CloakBrowser MCP का 30-सेकंड डेमो](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="CloakBrowser MCP का 30-सेकंड डेमो">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">पहला रन देखें: npm पैकेज शुरू करें, MCP क्लाइंट कनेक्ट करें, वेब रिसर्च, ऑटोमेशन या टेस्टिंग के लिए कहें, और वास्तविक ब्राउज़र परिणाम देखें।</p>

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30秒デモ
 
-<div class="clb-demo-video" markdown>
-[![CloakBrowser MCP 30秒デモ](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="CloakBrowser MCP 30秒デモ">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">最初の実行を確認できます。npm パッケージを起動し、MCP クライアントを接続して、Web 調査、自動化、またはテストを依頼し、実際のブラウザー結果を確認します。</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30-second demo
 
-<div class="clb-demo-video" markdown>
-[![30-second demo showing CloakBrowser MCP startup, humanized research prompt typing, web automation, and testing workflows](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="30-second demo showing CloakBrowser MCP startup, humanized research prompt typing, web automation, and testing workflows">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Watch the first run: start the npm package, connect an MCP client, ask for web research, automation, or testing, and inspect the real browser result.</p>

--- a/docs/index.pt-BR.md
+++ b/docs/index.pt-BR.md
@@ -21,8 +21,10 @@ tags:
 
 ## Demo de 30 segundos
 
-<div class="clb-demo-video" markdown>
-[![Demo de 30 segundos do CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="Demo de 30 segundos do CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Veja a primeira execução: inicie o pacote npm, conecte um cliente MCP, peça pesquisa na web, automação ou testes e inspecione o resultado em um navegador real.</p>

--- a/docs/index.ru.md
+++ b/docs/index.ru.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30-секундная демонстрация
 
-<div class="clb-demo-video" markdown>
-[![30-секундная демонстрация CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="30-секундная демонстрация CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Посмотрите первый запуск: запустите npm-пакет, подключите MCP-клиент, попросите выполнить веб-исследование, автоматизацию или тестирование и проверьте результат в настоящем браузере.</p>

--- a/docs/index.uk.md
+++ b/docs/index.uk.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30-секундна демонстрація
 
-<div class="clb-demo-video" markdown>
-[![30-секундна демонстрація CloakBrowser MCP](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="30-секундна демонстрація CloakBrowser MCP">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">Подивіться перший запуск: запустіть npm-пакет, підключіть MCP-клієнт, попросіть виконати веб-дослідження, автоматизацію або тестування й перевірте результат у справжньому браузері.</p>

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -21,8 +21,10 @@ tags:
 
 ## 30 秒演示
 
-<div class="clb-demo-video" markdown>
-[![CloakBrowser MCP 30 秒演示](assets/videos/30-second-demo.webp)](assets/videos/30-second-demo.mp4)
+<div class="clb-demo-video">
+<video controls preload="metadata" poster="assets/videos/30-second-demo-poster.png" aria-label="CloakBrowser MCP 30 秒演示">
+<source src="assets/videos/30-second-demo.mp4" type="video/mp4">
+</video>
 </div>
 
 <p class="clb-demo-caption">观看首次运行：启动 npm 包，连接 MCP 客户端，请求 Web 研究、自动化或测试，并检查真实浏览器中的结果。</p>

--- a/scripts/check-mcp-schema-updates.mjs
+++ b/scripts/check-mcp-schema-updates.mjs
@@ -19,9 +19,8 @@ const schemaSourceUrl = await resolveSchemaSourceUrl({
 });
 const schemaDir = process.env.MCP_SCHEMA_DIR ?? 'schemas/mcp';
 const checkedAt = process.env.MCP_SCHEMA_CHECKED_AT ?? toIsoDate();
+const writeSnapshots = readBooleanEnv('MCP_SCHEMA_WRITE_SNAPSHOTS', true);
 const latestSchemaPath = join(schemaDir, 'latest.json');
-
-await mkdir(schemaDir, { recursive: true });
 
 const downloadedSchema = await downloadSchema(schemaSourceUrl);
 const normalizedDownloaded = normalizeJson(downloadedSchema);
@@ -36,6 +35,7 @@ if (previous?.comparable === comparableDownloaded) {
     checked_at: checkedAt,
     latest_schema_path: latestSchemaPath,
     diff_summary: 'No changes detected in normalized schema content.',
+    snapshots_written: 'false',
   });
 
   process.stdout.write(
@@ -45,6 +45,7 @@ if (previous?.comparable === comparableDownloaded) {
         schemaSourceUrl,
         checkedAt,
         latestSchemaPath,
+        snapshotsWritten: false,
       },
       null,
       2,
@@ -53,11 +54,15 @@ if (previous?.comparable === comparableDownloaded) {
   process.exit(0);
 }
 
-const snapshotFilename = await allocateSnapshotFilename(schemaDir, checkedAt, comparableDownloaded);
-const snapshotPath = join(schemaDir, snapshotFilename);
+let snapshotPath = '';
 
-await writeFile(snapshotPath, normalizedDownloaded);
-await writeFile(latestSchemaPath, normalizedDownloaded);
+if (writeSnapshots) {
+  await mkdir(schemaDir, { recursive: true });
+  const snapshotFilename = await allocateSnapshotFilename(schemaDir, checkedAt, comparableDownloaded);
+  snapshotPath = join(schemaDir, snapshotFilename);
+  await writeFile(snapshotPath, normalizedDownloaded);
+  await writeFile(latestSchemaPath, normalizedDownloaded);
+}
 
 const diffSummary = describeTopLevelDiff(previous?.parsed, downloadedSchema);
 
@@ -69,6 +74,7 @@ const result = {
   snapshotPath,
   previousSchemaPath: previous?.path ?? '',
   diffSummary,
+  snapshotsWritten: writeSnapshots,
 };
 
 await appendGithubOutput({
@@ -79,6 +85,7 @@ await appendGithubOutput({
   snapshot_path: result.snapshotPath,
   previous_schema_path: result.previousSchemaPath,
   diff_summary: result.diffSummary,
+  snapshots_written: String(result.snapshotsWritten),
 });
 
 process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
@@ -145,4 +152,21 @@ function isMissingFileError(error) {
     typeof error.code === 'string' &&
     error.code === 'ENOENT'
   );
+}
+
+function readBooleanEnv(name, defaultValue) {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (value === undefined || value === '') {
+    return defaultValue;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  throw new Error(`${name} must be true or false.`);
 }

--- a/scripts/check-mcp-schema-updates.mjs
+++ b/scripts/check-mcp-schema-updates.mjs
@@ -6,14 +6,17 @@ import { appendGithubOutput } from '#scripts/lib/github-output';
 import {
   describeTopLevelDiff,
   normalizeJson,
+  normalizeSchemaForComparison,
   parseSchemaPayload,
   pickSnapshotFilename,
+  resolveSchemaSourceUrl,
   toIsoDate,
 } from '#scripts/lib/mcp-schema-monitor';
 
-const schemaSourceUrl =
-  process.env.MCP_SCHEMA_SOURCE_URL ??
-  'https://raw.githubusercontent.com/modelcontextprotocol/static/main/schemas/latest/server.schema.json';
+const schemaSourceUrl = await resolveSchemaSourceUrl({
+  catalogUrl: process.env.MCP_SCHEMA_CATALOG_URL,
+  explicitUrl: process.env.MCP_SCHEMA_SOURCE_URL,
+});
 const schemaDir = process.env.MCP_SCHEMA_DIR ?? 'schemas/mcp';
 const checkedAt = process.env.MCP_SCHEMA_CHECKED_AT ?? toIsoDate();
 const latestSchemaPath = join(schemaDir, 'latest.json');
@@ -22,10 +25,11 @@ await mkdir(schemaDir, { recursive: true });
 
 const downloadedSchema = await downloadSchema(schemaSourceUrl);
 const normalizedDownloaded = normalizeJson(downloadedSchema);
+const comparableDownloaded = normalizeSchemaForComparison(downloadedSchema);
 
 const previous = await readPreviousSchema(latestSchemaPath);
 
-if (previous?.normalized === normalizedDownloaded) {
+if (previous?.comparable === comparableDownloaded) {
   await appendGithubOutput({
     changed: 'false',
     schema_source_url: schemaSourceUrl,
@@ -49,7 +53,7 @@ if (previous?.normalized === normalizedDownloaded) {
   process.exit(0);
 }
 
-const snapshotFilename = await allocateSnapshotFilename(schemaDir, checkedAt, normalizedDownloaded);
+const snapshotFilename = await allocateSnapshotFilename(schemaDir, checkedAt, comparableDownloaded);
 const snapshotPath = join(schemaDir, snapshotFilename);
 
 await writeFile(snapshotPath, normalizedDownloaded);
@@ -102,7 +106,7 @@ async function readPreviousSchema(filePath) {
     const parsed = JSON.parse(text);
     return {
       path: filePath,
-      normalized: normalizeJson(parsed),
+      comparable: normalizeSchemaForComparison(parsed),
       parsed,
     };
   } catch (error) {
@@ -114,13 +118,13 @@ async function readPreviousSchema(filePath) {
   }
 }
 
-async function allocateSnapshotFilename(directoryPath, date, normalizedSchema) {
+async function allocateSnapshotFilename(directoryPath, date, comparableSchema) {
   const filenames = new Set(await listJsonFiles(directoryPath));
 
   const candidate = `mcp-schema-${date}.json`;
   if (filenames.has(candidate)) {
     const existingContent = await readFile(join(directoryPath, candidate), 'utf8');
-    if (normalizeJson(JSON.parse(existingContent)) === normalizedSchema) {
+    if (normalizeSchemaForComparison(JSON.parse(existingContent)) === comparableSchema) {
       return candidate;
     }
   }

--- a/scripts/lib/mcp-schema-monitor.mjs
+++ b/scripts/lib/mcp-schema-monitor.mjs
@@ -1,11 +1,21 @@
 import { basename } from 'node:path';
 
+export const defaultSchemaBaseUrl = 'https://static.modelcontextprotocol.io/schemas';
+export const defaultSchemaCatalogUrl =
+  'https://api.github.com/repos/modelcontextprotocol/static/contents/schemas?ref=main';
+
+const schemaVersionPattern = /^\d{4}-\d{2}-\d{2}$/;
+
 export function toIsoDate(value = new Date()) {
   return value.toISOString().slice(0, 10);
 }
 
 export function normalizeJson(value) {
   return `${JSON.stringify(sortJson(value), null, 2)}\n`;
+}
+
+export function normalizeSchemaForComparison(value) {
+  return normalizeJson(stripTopLevelComment(value));
 }
 
 export function sortJson(value) {
@@ -22,6 +32,90 @@ export function sortJson(value) {
   }
 
   return value;
+}
+
+function stripTopLevelComment(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const comparable = { ...value };
+  delete comparable.$comment;
+  return comparable;
+}
+
+export async function resolveSchemaSourceUrl({
+  catalogUrl = defaultSchemaCatalogUrl,
+  explicitUrl,
+  fetchImpl = fetch,
+  schemaBaseUrl = defaultSchemaBaseUrl,
+} = {}) {
+  const trimmedExplicitUrl = explicitUrl?.trim();
+  if (trimmedExplicitUrl) {
+    return trimmedExplicitUrl;
+  }
+
+  const catalog = await fetchSchemaCatalog({ catalogUrl, fetchImpl });
+  const version = selectLatestSchemaVersion(catalog);
+  return createSchemaSourceUrl({ schemaBaseUrl, version });
+}
+
+export async function fetchSchemaCatalog({ catalogUrl = defaultSchemaCatalogUrl, fetchImpl = fetch } = {}) {
+  const response = await fetchImpl(catalogUrl, {
+    headers: {
+      Accept: 'application/vnd.github+json, application/json',
+      'User-Agent': 'cloakbrowser-mcp-schema-monitor',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to discover MCP schema versions from ${catalogUrl}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const text = await response.text();
+  let parsed;
+
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`MCP schema catalog from ${catalogUrl} is invalid JSON.`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`MCP schema catalog from ${catalogUrl} must be a JSON array.`);
+  }
+
+  return parsed;
+}
+
+export function selectLatestSchemaVersion(entries) {
+  const versions = entries
+    .filter(isSchemaVersionDirectoryEntry)
+    .map((entry) => entry.name)
+    .sort();
+
+  const latest = versions[versions.length - 1];
+  if (!latest) {
+    throw new Error('MCP schema catalog does not contain any dated schema directories.');
+  }
+
+  return latest;
+}
+
+export function createSchemaSourceUrl({ schemaBaseUrl = defaultSchemaBaseUrl, version }) {
+  return `${schemaBaseUrl.replace(/\/$/, '')}/${version}/server.schema.json`;
+}
+
+function isSchemaVersionDirectoryEntry(entry) {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    entry.type === 'dir' &&
+    typeof entry.name === 'string' &&
+    schemaVersionPattern.test(entry.name)
+  );
 }
 
 export function parseSchemaPayload({ text, contentType, sourceUrl }) {

--- a/tests/unit/mcp-schema-monitor.test.ts
+++ b/tests/unit/mcp-schema-monitor.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 interface McpSchemaMonitorModule {
@@ -19,6 +24,8 @@ interface McpSchemaMonitorModule {
 const monitor = (await import(
   new URL('../../scripts/lib/mcp-schema-monitor.mjs', import.meta.url).href
 )) as unknown as McpSchemaMonitorModule;
+
+const checkScriptPath = fileURLToPath(new URL('../../scripts/check-mcp-schema-updates.mjs', import.meta.url));
 
 describe('mcp schema monitor helpers', () => {
   it('normalizes object keys recursively for stable comparisons', () => {
@@ -166,4 +173,55 @@ describe('mcp schema monitor helpers', () => {
     expect(summary).toContain('added keys: c');
     expect(summary).toContain('removed keys: a');
   });
+
+  it('can report schema changes without writing snapshots', () => {
+    const root = mkdirTempDir('cloakbrowser-mcp-schema-check-');
+    const schemaDir = path.join(root, 'schemas', 'mcp');
+    const githubOutputPath = path.join(root, 'github-output.txt');
+    const previousSchema = { $id: 'https://example.test/schema.json', definitions: { Old: {} } };
+    const nextSchema = {
+      $id: 'https://example.test/schema.json',
+      definitions: { New: {}, Old: {} },
+    };
+
+    mkdirSync(schemaDir, { recursive: true });
+    writeFileSync(path.join(schemaDir, 'latest.json'), monitor.normalizeJson(previousSchema));
+
+    const result = spawnSync(process.execPath, [checkScriptPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: githubOutputPath,
+        MCP_SCHEMA_CHECKED_AT: '2026-07-08',
+        MCP_SCHEMA_DIR: schemaDir,
+        MCP_SCHEMA_SOURCE_URL: `data:application/json,${encodeURIComponent(JSON.stringify(nextSchema))}`,
+        MCP_SCHEMA_WRITE_SNAPSHOTS: 'false',
+      },
+    });
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+
+    const output = readFileSync(githubOutputPath, 'utf8');
+    expect(output).toContain('changed=true');
+    expect(output).toContain('snapshots_written=false');
+
+    const parsed = JSON.parse(result.stdout) as {
+      changed: boolean;
+      snapshotPath: string;
+      snapshotsWritten: boolean;
+    };
+    expect(parsed.changed).toBe(true);
+    expect(parsed.snapshotPath).toBe('');
+    expect(parsed.snapshotsWritten).toBe(false);
+    expect(readFileSync(path.join(schemaDir, 'latest.json'), 'utf8')).toBe(
+      monitor.normalizeJson(previousSchema),
+    );
+    expect(readdirSync(schemaDir)).toEqual(['latest.json']);
+    expect(existsSync(path.join(schemaDir, 'mcp-schema-2026-07-08.json'))).toBe(false);
+  });
 });
+
+function mkdirTempDir(prefix: string): string {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}

--- a/tests/unit/mcp-schema-monitor.test.ts
+++ b/tests/unit/mcp-schema-monitor.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 interface McpSchemaMonitorModule {
+  createSchemaSourceUrl(input: { schemaBaseUrl?: string; version: string }): string;
   describeTopLevelDiff(previousSchema: unknown, nextSchema: unknown): string;
   normalizeJson(value: unknown): string;
+  normalizeSchemaForComparison(value: unknown): string;
   parseSchemaPayload(input: { text: string; contentType?: string; sourceUrl: string }): unknown;
   pickSnapshotFilename(input: { date: string; existingFilenames: Set<string> }): string;
+  resolveSchemaSourceUrl(input?: {
+    catalogUrl?: string;
+    explicitUrl?: string;
+    fetchImpl?: typeof fetch;
+    schemaBaseUrl?: string;
+  }): Promise<string>;
+  selectLatestSchemaVersion(entries: unknown[]): string;
 }
 
 const monitor = (await import(
@@ -42,6 +51,62 @@ describe('mcp schema monitor helpers', () => {
     );
   });
 
+  it('selects the latest dated schema directory', () => {
+    const version = monitor.selectLatestSchemaVersion([
+      { name: '2025-10-17', type: 'dir' },
+      { name: 'latest', type: 'dir' },
+      { name: 'README.md', type: 'file' },
+      { name: '2025-12-11', type: 'dir' },
+      { name: '2025-09-29', type: 'dir' },
+    ]);
+
+    expect(version).toBe('2025-12-11');
+  });
+
+  it('builds canonical static schema URLs', () => {
+    expect(
+      monitor.createSchemaSourceUrl({
+        schemaBaseUrl: 'https://static.example.test/schemas/',
+        version: '2025-12-11',
+      }),
+    ).toBe('https://static.example.test/schemas/2025-12-11/server.schema.json');
+  });
+
+  it('resolves the latest schema URL from the catalog', async () => {
+    const fetchImpl = async () =>
+      new Response(
+        JSON.stringify([
+          { name: '2025-09-29', type: 'dir' },
+          { name: '2025-12-11', type: 'dir' },
+        ]),
+        {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
+      );
+
+    await expect(
+      monitor.resolveSchemaSourceUrl({
+        catalogUrl: 'https://api.example.test/schemas',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        schemaBaseUrl: 'https://static.example.test/schemas',
+      }),
+    ).resolves.toBe('https://static.example.test/schemas/2025-12-11/server.schema.json');
+  });
+
+  it('keeps an explicit schema source URL without catalog discovery', async () => {
+    const fetchImpl = async () => {
+      throw new Error('unexpected fetch');
+    };
+
+    await expect(
+      monitor.resolveSchemaSourceUrl({
+        explicitUrl: ' https://example.test/custom.schema.json ',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBe('https://example.test/custom.schema.json');
+  });
+
   it('rejects HTML responses when schema source does not return JSON', () => {
     expect(() =>
       monitor.parseSchemaPayload({
@@ -50,6 +115,30 @@ describe('mcp schema monitor helpers', () => {
         sourceUrl: 'https://example.invalid/schema.json',
       }),
     ).toThrow('Expected JSON');
+  });
+
+  it('ignores top-level comments when comparing schema content', () => {
+    const local = monitor.normalizeSchemaForComparison({
+      $comment: 'Bundled locally.',
+      $id: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+      definitions: {
+        ServerDetail: {
+          type: 'object',
+        },
+      },
+    });
+
+    const upstream = monitor.normalizeSchemaForComparison({
+      $comment: 'Generated upstream.',
+      $id: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+      definitions: {
+        ServerDetail: {
+          type: 'object',
+        },
+      },
+    });
+
+    expect(local).toBe(upstream);
   });
 
   it('rejects invalid JSON responses', () => {


### PR DESCRIPTION
## Summary

- Fixed the scheduled MCP schema updater by discovering the latest dated schema directory from `modelcontextprotocol/static` and downloading the canonical `static.modelcontextprotocol.io` schema URL.
- Extracted schema update detection into a local composite action that owns Node setup, reporting, and action outputs while the workflow keeps PR creation logic.
- Added check-only schema detection support for future notification-only action usage, plus unit coverage for no-write behavior.
- Updated the MkDocs home pages across locales to use controlled MP4 playback while keeping the README demo as an animated WebP thumbnail linked to the MP4.

## Checklist

- [x] I ran `npm run check` locally and it passed.
- [x] If I changed public behavior, I updated `README.md` and relevant docs in `docs/`.
- [x] If I changed local bridge tools, I updated `docs/tools.md`. Not applicable: no local bridge tools changed.
- [x] If I changed bridge configuration, I updated `docs/configuration.md`. Not applicable: no bridge configuration changed.
- [x] Upstream Playwright MCP tool schemas, descriptions, and responses are not copied or mutated.
- [x] I added/updated tests (unit and/or integration as appropriate).
- [ ] I added an entry to `CHANGELOG.md` under `## [Unreleased]`. Not applicable: CI/docs maintenance only; no runtime package behavior change.
- [x] I reviewed security implications and documented them below.

## Security review

- Bridge and child-process behavior: unchanged; runtime proxying, child process spawning, and upstream Playwright MCP tool contracts are not altered.
- Filesystem behavior: the existing schema updater still writes only to `schemas/mcp` or `MCP_SCHEMA_DIR` when snapshot writing is enabled; the reusable action can run in no-write check-only mode.
- Docker and logging: unchanged.
- Secrets, tokens, and OIDC: no new secrets or OIDC usage. The schema workflow keeps write permissions only on the job that creates schema update PRs.
- Registry publishing: unchanged.
- External network access: the schema checker contacts the MCP static GitHub catalog and the canonical static schema URL; action inputs allow overriding those URLs for future reuse.

## Test evidence

- `docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color`: passed.
- `python3 -m pipx run zizmor --min-severity high .`: passed; no findings to report.
- `npm run docs:build`: passed with the existing MkDocs 2.0 notice and generated CLI timestamp messages.
- `npm run docs:seo:validate`: passed.
- `npm run check`: passed; 25 Vitest files passed, 199 tests passed, 4 skipped, and e2e passed with 1 file and 6 tests.
- Live schema check with `MCP_SCHEMA_WRITE_SNAPSHOTS=false`: passed; resolved `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` and reported no changes against the current stored schema.
- CloakBrowser MCP docs video verification: passed; video loaded with controls, no autoplay/loop, no console warnings/errors, MP4 served as `video/mp4`, and GitHub Pages supports byte-range `206 Partial Content` for rewind/scrubbing.
