### PR TITLE
feat: add native Windows ARM64 support

### DIFF
--- a/docs/specs/win32-arm64-support/decisions.yaml
+++ b/docs/specs/win32-arm64-support/decisions.yaml
@@ -1,0 +1,642 @@
+schema_version: 1
+spec_slug: win32-arm64-support
+decisions:
+  - id: outcome.target-platform
+    revision: 1
+    category: outcome
+    state: answered
+    provenance: user
+    evidence:
+      - 'User request: add win32-arm64 support.'
+      - 'https://github.com/swimmwatch/cloakbrowser-mcp/issues/89'
+    question: null
+    answer:
+      selected_ids:
+        - native-win32-arm64
+      text: 'Support the npm/npx runtime on Windows ARM64 where Node.js reports process.platform=win32 and process.arch=arm64.'
+    rationale: 'The request and issue identify the unsupported Node.js platform/architecture pair directly.'
+    last_tool_status: committed
+    supersedes_revision: null
+    requirement_ids:
+      - R1
+
+  - id: stakeholders.primary-users
+    revision: 1
+    category: outcome
+    state: observed
+    provenance: repository
+    evidence:
+      - 'Issue #89 reports failure on Windows 11 ARM64 hardware using npx and Node.js 24.'
+    question: null
+    answer:
+      selected_ids: []
+      text: 'Primary users are operators running the recommended local npm/npx installation on ARM-based Windows 11 devices.'
+    rationale: 'Docker works as a heavier workaround, while the default local path fails before bridge startup.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R1
+
+  - id: scope.native-node-runtime
+    revision: 1
+    category: scope
+    state: answered
+    provenance: user
+    evidence:
+      - 'The requested target is named win32-arm64.'
+      - "Issue #89 records the error 'Unsupported platform: win32 arm64'."
+    question: null
+    answer:
+      selected_ids:
+        - node-win32-arm64
+      text: 'The target is native ARM64 Node.js on Windows, not x64 Node.js running under Windows-on-ARM emulation.'
+    rationale: 'Node.js platform and architecture are the observable inputs used by the upstream binary resolver.'
+    last_tool_status: committed
+    supersedes_revision: null
+    requirement_ids:
+      - R1
+
+  - id: scope.license-tiers
+    revision: 1
+    category: scope
+    state: answered
+    provenance: user
+    evidence:
+      - 'Issue #89 demonstrates the default free npm/npx path.'
+      - 'CloakBrowser supports free and Pro binary resolution.'
+      - 'The upstream resolver deliberately does not fall back from a valid Pro license to the free binary.'
+    question:
+      text: 'Must the Windows ARM64 support claim cover both CloakBrowser Free and Pro binary paths?'
+      kind: single
+      options:
+        - id: free-and-pro
+          label: Require Free and Pro (Recommended)
+          description: 'Do not advertise Windows ARM64 until both existing license paths can resolve and launch native ARM64 binaries.'
+        - id: free-only
+          label: Ship Free first
+          description: "Fix the issue's default free path first and document Pro as unsupported on Windows ARM64 until its native artifact is available."
+    answer:
+      selected_ids:
+        - free-and-pro
+      text: ''
+    rationale: 'The public platform claim must cover both existing CloakBrowser license paths and must not strand Pro users on a platform advertised as supported.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids:
+      - R1
+      - R3
+      - R4
+
+  - id: current.upstream-support
+    revision: 1
+    category: scope
+    state: observed
+    provenance: authoritative-doc
+    evidence:
+      - 'Installed cloakbrowser@0.5.1 maps win32-x64 to windows-x64 and rejects win32-arm64 in dist/config.js.'
+      - 'npm latest is cloakbrowser@0.5.2 as of 2026-07-25.'
+      - 'CloakBrowser npm source at gitHead a5f2c33ff9aa27cabd93871d714ee1469fb8fcc5 still maps only win32-x64.'
+      - 'The signed free Chromium release chromium-v146.0.7680.177.5 publishes windows-x64 but no windows-arm64 archive.'
+      - 'Context7 /cloakhq/cloakbrowser documentation lists Windows x86_64 only.'
+    question: null
+    answer:
+      selected_ids: []
+      text: 'No currently published stable CloakBrowser JavaScript package and free signed binary release provides native Windows ARM64 support.'
+    rationale: 'A cloakbrowser-mcp dependency-only change cannot produce native support until the upstream package and binary exist.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R2
+
+  - id: architecture.binary-ownership
+    revision: 1
+    category: architecture
+    state: observed
+    provenance: repository
+    evidence:
+      - 'src/bridge/config.ts imports ensureBinary, binaryInfo, buildLaunchOptions, and getDefaultStealthArgs from cloakbrowser.'
+      - 'configureCloakRuntime delegates binary resolution to ensureBinary and forwards the returned executable path to Playwright MCP.'
+      - 'cloakbrowser_binary_info and doctor delegate platform metadata to binaryInfo.'
+      - 'AGENTS.md requires a thin bridge and prohibits replacing upstream browser contracts.'
+    question: null
+    answer:
+      selected_ids: []
+      text: 'CloakBrowser owns platform detection, archive naming, download URLs, integrity verification, cache layout, and executable resolution; cloakbrowser-mcp consumes those APIs.'
+    rationale: 'Keeping ownership upstream preserves the bridge boundary and prevents duplicate platform logic.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R2
+      - R8
+
+  - id: architecture.delivery-strategy
+    revision: 1
+    category: architecture
+    state: answered
+    provenance: user
+    evidence:
+      - 'The required upstream JavaScript mapping and native signed archive do not exist in stable releases as of 2026-07-25.'
+      - 'This repository currently depends on cloakbrowser ^0.5.1 and deliberately delegates binary management.'
+    question:
+      text: 'How should this workstream handle the missing upstream Windows ARM64 package and binary support?'
+      kind: single
+      options:
+        - id: consume-stable-upstream
+          label: Consume stable upstream support (Recommended)
+          description: 'Keep this bridge thin and make implementation depend on the first stable cloakbrowser release with native win32-arm64 mapping and a signed free windows-arm64 archive.'
+        - id: include-upstream-work
+          label: Include upstream work
+          description: 'Expand the workstream to define the required CloakBrowser build, JavaScript wrapper, artifact, and publication changes before consuming them here.'
+        - id: x64-emulation-fallback
+          label: Use x64 emulation
+          description: 'Treat the existing windows-x64 build under Windows emulation as the fallback instead of requiring a native ARM64 archive.'
+    answer:
+      selected_ids:
+        - consume-stable-upstream
+      text: ''
+    rationale: 'Keep cloakbrowser-mcp within its existing thin-bridge boundary and consume the first stable upstream release that provides native, signed Windows ARM64 support.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids:
+      - R2
+
+  - id: interfaces.public-surface
+    revision: 1
+    category: interfaces
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'The requested capability is a new supported platform for the existing npm path.'
+      - 'The project exposes only the upstream Playwright MCP tools and two fixed local introspection tools.'
+    question: null
+    answer:
+      selected_ids:
+        - additive-no-new-interface
+      text: 'Do not add or change CLI flags, environment variables, MCP tools, tool schemas, transports, or server metadata solely for Windows ARM64 support.'
+    rationale: 'The existing APIs already delegate platform detection and binary resolution; an additive platform should not create a parallel contract.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R8
+
+  - id: flows.default-install
+    revision: 1
+    category: flows
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'README.md recommends npx -y cloakbrowser-mcp@latest.'
+      - 'prepareBridgeRuntime calls cloakbrowser ensureBinary before launching the upstream MCP bridge.'
+    question: null
+    answer:
+      selected_ids:
+        - existing-default-flow
+      text: 'On native Windows ARM64, the existing default npm/npx flow must resolve, download, verify, cache, and launch a native CloakBrowser binary without special flags; subsequent starts may reuse the verified cache.'
+    rationale: 'Support should make the documented default path work rather than introduce a platform-specific setup path.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R3
+      - R4
+
+  - id: operations.cache-transition
+    revision: 1
+    category: operations
+    state: answered
+    provenance: user
+    evidence:
+      - 'CloakBrowser 0.5.2 uses a version-based cache directory and chrome.exe path without an architecture component.'
+      - 'A Windows ARM device may have an existing windows-x64 cache from running x64 Node.js before switching to native ARM64 Node.js.'
+    question:
+      text: 'What compatibility guarantee should apply when a Windows ARM user already has an x64 CloakBrowser binary cached for the same Chromium version?'
+      kind: single
+      options:
+        - id: transparent-native-replacement
+          label: Replace transparently (Recommended)
+          description: 'Require the upstream dependency to distinguish or validate architectures and obtain the ARM64 binary without asking the user to purge the cache.'
+        - id: documented-cache-reset
+          label: Allow one-time cache reset
+          description: 'Permit support to require a documented one-time cache removal when an incompatible x64 binary is already cached.'
+    answer:
+      selected_ids:
+        - transparent-native-replacement
+      text: ''
+    rationale: 'Existing users must not have to diagnose and manually purge an x64 cache when switching to native ARM64 Node.js.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids:
+      - R5
+
+  - id: failures.binary-acquisition
+    revision: 1
+    category: failures
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'CloakBrowser owns archive availability, detached signature verification, checksums, and download errors.'
+      - 'The bridge currently propagates configureCloakRuntime failures after cleaning its temporary runtime directory.'
+    question: null
+    answer:
+      selected_ids:
+        - fail-closed
+      text: 'A missing, unverified, corrupt, or non-executable Windows ARM64 binary must fail closed with a clear diagnostic and must not silently run an unverified download or switch to an unrelated browser.'
+    rationale: 'This preserves current supply-chain and launch-failure behavior.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R7
+
+  - id: security.binary-integrity
+    revision: 1
+    category: security
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'CloakBrowser releases publish SHA256SUMS and SHA256SUMS.sig.'
+      - 'The upstream JavaScript package embeds Ed25519 verification keys and verifies downloaded binaries.'
+    question: null
+    answer:
+      selected_ids:
+        - preserve-signed-downloads
+      text: 'Windows ARM64 artifacts must use the same signed-manifest and checksum verification path as existing supported platforms; the bridge must not vendor an unsigned binary or bypass verification.'
+    rationale: 'Adding a platform must not weaken the existing binary trust boundary.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R7
+
+  - id: quality.native-ci
+    revision: 1
+    category: quality
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'Current CI tests npm on Linux x64/arm64, macOS arm64/x64, and Windows x64 across the supported Node.js versions.'
+      - 'GitHub documents the standard public-repository ARM64 Windows runner label windows-11-arm.'
+      - 'Existing packaged CLI E2E tests use a fake upstream and do not prove native CloakBrowser download or launch.'
+    question: null
+    answer:
+      selected_ids:
+        - native-runner-and-browser-smoke
+      text: 'Windows ARM64 support must be gated on the existing quality/package suites on a native windows-11-arm runner for the supported Node.js matrix plus an automated default-engine smoke that proves the signed ARM64 binary is resolved and launched.'
+    rationale: 'A platform claim requires native execution evidence, not only mocked bridge or CLI help tests.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R10
+
+  - id: quality.pro-validation
+    revision: 1
+    category: quality
+    state: answered
+    provenance: user
+    evidence:
+      - 'The selected platform scope includes both Free and Pro paths.'
+      - 'The free archive can be downloaded and launched in public CI without credentials.'
+      - 'The Pro download path requires a valid license and must not fall back to Free.'
+      - 'The specification workflow must not request or persist credentials.'
+    question:
+      text: 'How should native Windows ARM64 Pro support be verified before the platform is advertised?'
+      kind: single
+      options:
+        - id: protected-ci-smoke
+          label: Protected CI smoke (Recommended)
+          description: 'Run a non-fork protected workflow on windows-11-arm using an existing repository secret, redact it, and require a native Pro download and browser launch; never expose or persist the credential.'
+        - id: maintainer-manual-smoke
+          label: Maintainer release gate
+          description: 'Require a maintainer to run and record a native Pro download and launch on Windows ARM64 before release, with the credential supplied only to that local process.'
+        - id: upstream-evidence-only
+          label: Trust upstream evidence
+          description: 'Accept the upstream stable package, signed Pro manifest, and upstream test evidence without executing a Pro launch in this repository.'
+    answer:
+      selected_ids:
+        - protected-ci-smoke
+      text: ''
+    rationale: 'A protected native CI gate gives repeatable proof for the non-fallback Pro path while keeping the credential unavailable to forked pull requests and logs.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids:
+      - R11
+
+  - id: operations.diagnostics
+    revision: 1
+    category: operations
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'doctor and cloakbrowser_binary_info already delegate to cloakbrowser binaryInfo.'
+      - 'binaryInfo returns platform, tier, binaryPath, installed, cacheDir, version, and downloadUrl.'
+    question: null
+    answer:
+      selected_ids:
+        - existing-diagnostics
+      text: 'On Windows ARM64, doctor and cloakbrowser_binary_info must identify the resolved windows-arm64 platform and the selected Free or Pro binary through their existing output shapes; failures must remain actionable and contain no credential.'
+    rationale: 'Operators need to verify which native artifact is selected without a new diagnostic interface.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R6
+      - R8
+
+  - id: flows.concurrent-cache-safety
+    revision: 1
+    category: flows
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'CloakBrowser owns download, extraction, verification, and cache cleanup.'
+      - 'The bridge removes its temporary runtime directory when configuration fails.'
+    question: null
+    answer:
+      selected_ids:
+        - preserve-cache-safety
+      text: 'Concurrent or interrupted first starts must not leave a partial, unverified, or wrong-architecture executable treated as installed; bridge temporary runtime state must still be cleaned after failure.'
+    rationale: 'The new platform must be no weaker than existing platforms under interruption or concurrent startup.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R7
+
+  - id: security.pro-ci-credential
+    revision: 1
+    category: security
+    state: answered
+    provenance: user
+    evidence:
+      - 'quality.pro-validation selected protected-ci-smoke.'
+      - 'AGENTS.md requires least-privilege workflow permissions and prohibits exposing secrets.'
+    question: null
+    answer:
+      selected_ids:
+        - protected-non-fork-secret
+      text: 'The Pro credential may be used only by a protected non-fork Windows ARM64 CI job, must be masked and excluded from command output and artifacts, and must not be made available to untrusted pull-request code.'
+    rationale: 'This is the security consequence of the selected repeatable Pro validation gate.'
+    last_tool_status: committed
+    supersedes_revision: null
+    requirement_ids:
+      - R11
+
+  - id: operations.rollback
+    revision: 1
+    category: operations
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'The selected delivery strategy consumes a stable upstream dependency and does not add local binary ownership.'
+      - 'Platform claims are maintained in generated compatibility data and human-authored testing documentation.'
+    question: null
+    answer:
+      selected_ids:
+        - reversible-consumer-change
+      text: 'If the upstream stable release is withdrawn or fails the native gates, the consumer dependency floor, Windows ARM64 CI inclusion, and public support claim must be reverted together; existing platforms and user cache data must not be destructively removed.'
+    rationale: 'The additive consumer change has a bounded rollback that does not require a data migration.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R13
+
+  - id: compatibility.existing-platforms
+    revision: 1
+    category: compatibility
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'README.md and docs/data/version-compatibility.json list five existing npm platform combinations.'
+      - 'The request is additive.'
+    question: null
+    answer:
+      selected_ids:
+        - preserve-existing
+      text: 'Linux x64/arm64, macOS x64/arm64, Windows x64, both transports, local tools, and forwarded upstream Playwright MCP contracts must remain unchanged.'
+    rationale: 'The new platform must not regress established public behavior.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R9
+
+  - id: compatibility.dependency-floor
+    revision: 1
+    category: compatibility
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'package.json currently declares cloakbrowser ^0.5.1.'
+      - 'A future compatible release could otherwise resolve opportunistically without documenting the actual minimum supported version.'
+    question: null
+    answer:
+      selected_ids:
+        - explicit-minimum
+      text: 'The cloakbrowser dependency lower bound and lockfile must identify the first accepted stable upstream version that satisfies the Windows ARM64 contract.'
+    rationale: 'An explicit floor makes installations and the compatibility table reproducible.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R2
+
+  - id: documentation.platform-claim
+    revision: 1
+    category: operations
+    state: assumed
+    provenance: agent-default
+    evidence:
+      - 'README.md, docs/testing.md, docs/version-compatibility.md, and docs/data/version-compatibility.json currently claim Windows x64 only.'
+      - 'AGENTS.md requires localized documentation updates for changed human-authored Markdown.'
+    question: null
+    answer:
+      selected_ids:
+        - update-generated-and-localized-contracts
+      text: 'After native acceptance passes, public compatibility and testing documentation must add Windows ARM64, generated compatibility data must remain the source of truth, and every affected localized page and translation-manifest entry must be updated consistently.'
+    rationale: 'Documentation must not advertise support before it is verified or leave localized contracts stale.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids:
+      - R12
+
+  - id: documentation.spec-localization
+    revision: 1
+    category: operations
+    state: blocked
+    provenance: authoritative-doc
+    evidence:
+      - 'Project policy requires localized counterparts for new human-authored Markdown under docs/.'
+      - "DeepL MCP translate_text returned 'Quota for this billing period has been exceeded' for every attempted locale on 2026-07-25."
+    question: null
+    answer:
+      selected_ids: []
+      text: 'The new specification page remains English-only until DeepL MCP quota is restored; ru, be, uk, es, pt-BR, zh, ja, de, fr, and hi are explicitly deferred, and the translation manifest is intentionally not refreshed.'
+    rationale: 'Creating untranslated placeholder files or updating hashes without real translations would violate the documentation policy.'
+    last_tool_status: failed
+    supersedes_revision: null
+    requirement_ids: []
+
+  - id: documentation.plan-localization
+    revision: 1
+    category: operations
+    state: blocked
+    provenance: authoritative-doc
+    evidence:
+      - 'Project policy requires localized counterparts for new human-authored Markdown under docs/.'
+      - "DeepL MCP translate_text returned 'Quota for this billing period has been exceeded' on 2026-07-25."
+      - 'npm run docs:translations:check reports 110 missing localized counterparts for the English specification and planning bundle.'
+    question: null
+    answer:
+      selected_ids: []
+      text: 'The implementation-plan bundle remains English-only until DeepL MCP quota is restored; ru, be, uk, es, pt-BR, zh, ja, de, fr, and hi are explicitly deferred, and the translation manifest is intentionally not refreshed.'
+    rationale: 'Creating untranslated placeholder files or updating hashes without real translations would violate the documentation policy.'
+    last_tool_status: failed
+    supersedes_revision: null
+    requirement_ids: []
+
+  - id: approval.spec
+    revision: 1
+    category: approval
+    state: answered
+    provenance: user
+    evidence:
+      - 'docs/specs/win32-arm64-support/spec.md is complete with Status: Draft.'
+      - 'All material requirement decisions are resolved and mapped to R1-R13.'
+      - 'Formatting, docs build, SEO, compatibility generation, build, unit/integration tests, and packaged E2E tests pass.'
+      - 'The full check is blocked only by the explicitly deferred specification localizations after DeepL MCP quota exhaustion.'
+    question:
+      text: 'How should the completed Windows ARM64 specification draft proceed?'
+      kind: single
+      options:
+        - id: approve
+          label: Approve specification (Recommended)
+          description: 'Set Status to Approved and treat this draft as the implementation contract, while retaining the upstream-release and localization blockers.'
+        - id: request-changes
+          label: Request changes
+          description: 'Keep Status as Draft, reopen affected decisions, and revise the specification.'
+        - id: leave-draft
+          label: Leave as draft
+          description: 'Stop the specification workflow without approval or further changes.'
+    answer:
+      selected_ids:
+        - approve
+      text: ''
+    rationale: 'The complete draft is approved as the implementation contract; the stable upstream-release prerequisite and the non-material specification-localization deferral remain visible blockers.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids: []
+
+  - id: planning.pro-workflow-gate
+    revision: 1
+    category: planning
+    state: answered
+    provenance: user
+    evidence:
+      - 'The approved specification requires a protected, non-fork Windows ARM64 Pro CI gate.'
+      - 'The existing CI workflow supports pull_request and workflow_dispatch and has top-level contents: read.'
+      - 'Existing production workflows use GitHub environments for protected external actions.'
+      - 'No current workflow references a CloakBrowser license secret.'
+    question:
+      text: 'Which workflow protection model should the implementation plan use for the Windows ARM64 Pro smoke?'
+      kind: single
+      options:
+        - id: protected-environment-ci
+          label: Protected CI environment (Recommended)
+          description: 'Add a same-repository PR/manual CI job guarded by a preconfigured windows-arm64-pro GitHub Environment with required reviewers; skip forks and require a separate maintainer settings gate.'
+        - id: post-merge-manual
+          label: Post-merge manual validation
+          description: 'Land unadvertised test infrastructure first, run the secret-bearing smoke manually from the default branch, then add the public support claim in a follow-up change.'
+    answer:
+      selected_ids:
+        - protected-environment-ci
+      text: ''
+    rationale: 'Use a protected GitHub Environment to keep the Pro gate repeatable while preventing the credential from reaching fork pull requests or unreviewed workflow execution.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids:
+      - R11
+
+  - id: planning.pro-secret-identifier
+    revision: 1
+    category: planning
+    state: answered
+    provenance: user
+    evidence:
+      - 'The approved specification requires use of an existing repository secret but does not name its workflow identifier.'
+      - 'CLOAKBROWSER_LICENSE_KEY is the existing runtime environment-variable contract consumed by CloakBrowser.'
+    question:
+      text: 'Which non-sensitive GitHub Actions secret identifier should the plan bind to the existing CloakBrowser Pro credential?'
+      kind: single
+      options:
+        - id: cloakbrowser-license-key
+          label: CLOAKBROWSER_LICENSE_KEY (Recommended)
+          description: 'Use secrets.CLOAKBROWSER_LICENSE_KEY and pass it only through the step environment variable of the protected Pro smoke.'
+        - id: defer-binding
+          label: Defer identifier binding
+          description: 'Keep the workflow packet blocked at a manual gate until a maintainer supplies a different non-sensitive secret identifier; never request the credential value.'
+    answer:
+      selected_ids:
+        - defer-binding
+      text: ''
+    rationale: 'Do not guess the repository secret identifier. The workflow packet remains blocked at a manual maintainer gate until a non-sensitive identifier is supplied; the credential value must never be requested or persisted.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids:
+      - R11
+
+  - id: approval.plan
+    revision: 1
+    category: approval
+    state: answered
+    provenance: user
+    evidence:
+      - 'The approved R1-R13 contract is decomposed into seven self-contained packets with explicit dependencies, file ownership, verification, rollback, and manual gates.'
+      - 'All packet links and required sections validate, Prettier passes, docs build and SEO validation pass, and the only documentation failure is the explicitly deferred DeepL localization blocker.'
+      - 'The protected Pro workflow model is selected, while its non-sensitive secret identifier remains an explicit packet 05 manual gate.'
+    question:
+      text: 'How should the completed Windows ARM64 implementation plan proceed?'
+      kind: single
+      options:
+        - id: approve
+          label: Approve plan (Recommended)
+          description: 'Set the plan to Approved and make packet 01 eligible for separate explicit implementation authorization; approval does not start execution.'
+        - id: request-changes
+          label: Request changes
+          description: 'Keep the plan in Draft and revise the affected packets before implementation.'
+        - id: leave-draft
+          label: Leave as draft
+          description: 'Stop the planning workflow without approval or implementation.'
+    answer:
+      selected_ids:
+        - approve
+      text: ''
+    rationale: 'The packet set is approved as the implementation plan. This approval does not authorize execution, external mutations, credentials, or the first packet.'
+    last_tool_status: answered
+    supersedes_revision: null
+    requirement_ids: []
+
+  - id: scope.docker
+    revision: 1
+    category: scope
+    state: not_applicable
+    provenance: repository
+    evidence:
+      - 'Issue #89 identifies Docker linux/arm64 as an existing workaround.'
+      - 'Docker releases already target linux/amd64 and linux/arm64.'
+    question: null
+    answer:
+      selected_ids: []
+      text: 'No new Windows container image or Docker platform is required.'
+    rationale: 'The gap is the local Windows npm/npx runtime, not the Linux container distribution.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids: []
+
+  - id: privacy.data-handling
+    revision: 1
+    category: security
+    state: not_applicable
+    provenance: repository
+    evidence:
+      - 'The change concerns platform selection, binary distribution, CI, and compatibility documentation.'
+    question: null
+    answer:
+      selected_ids: []
+      text: 'No new user data, credentials, telemetry, retention, or deletion behavior is introduced.'
+    rationale: 'The requested support does not add a data-processing surface.'
+    last_tool_status: not_asked
+    supersedes_revision: null
+    requirement_ids: []

--- a/docs/specs/win32-arm64-support/spec.md
+++ b/docs/specs/win32-arm64-support/spec.md
@@ -1,0 +1,246 @@
+# Native Windows ARM64 npm Support
+
+Status: Approved
+
+Issue: [#89](https://github.com/swimmwatch/cloakbrowser-mcp/issues/89)
+
+Decision ledger: [decisions.yaml](decisions.yaml)
+
+## Outcome
+
+The documented local npm/npx installation of `cloakbrowser-mcp` must work on
+Windows ARM64 when native Node.js reports `process.platform === "win32"` and
+`process.arch === "arm64"`. Both CloakBrowser Free and Pro paths must resolve,
+verify, and launch native ARM64 Chromium without platform-specific user
+configuration.
+
+The support claim is for a native Windows ARM64 executable. Running the existing
+Windows x64 executable through emulation does not satisfy this specification.
+
+## Current State And External Prerequisite
+
+`cloakbrowser-mcp` delegates platform detection, downloads, integrity checks,
+cache management, and executable resolution to the `cloakbrowser` package. The
+bridge consumes `ensureBinary()` and `binaryInfo()` and forwards the resolved
+path to upstream Playwright MCP.
+
+As observed on 2026-07-25:
+
+- `cloakbrowser-mcp` declares `cloakbrowser` `^0.5.1`;
+- the latest stable package is `cloakbrowser@0.5.2`;
+- that package maps `win32-x64` to `windows-x64` and rejects `win32-arm64`;
+- its documented platform list includes Windows x64 only; and
+- the current signed Free release has no `windows-arm64` archive.
+
+Implementation in this repository is therefore blocked until a stable
+`cloakbrowser` release satisfies R2. This specification does not authorize a
+fork, prerelease dependency, local downloader, or upstream publication work.
+
+## Requirements
+
+### R1. Supported Platform
+
+The npm distribution must support native Windows ARM64 for every Node.js version
+allowed by this repository's `engines.node` contract. The support claim must
+cover both Free and Pro CloakBrowser resolution. An x64 Node.js process on
+Windows ARM64 continues to use the existing Windows x64 path and is not the
+target of this change.
+
+### R2. Stable Upstream Dependency Gate
+
+The consumer change may proceed only after a stable `cloakbrowser` release:
+
+1. recognizes `process.platform === "win32"` with
+   `process.arch === "arm64"`;
+2. maps that pair to the canonical `windows-arm64` platform tag and
+   `cloakbrowser-windows-arm64.zip` archive name;
+3. publishes a native Free archive referenced by a valid signed checksum
+   manifest;
+4. makes a native Pro archive available through the existing authenticated
+   download path and its signed checksum manifest;
+5. returns coherent `binaryInfo()` data for `windows-arm64`; and
+6. satisfies the transparent cache transition in R5.
+
+`package.json` and the lockfile must set the first accepted stable release as
+the minimum `cloakbrowser` version. The bridge must continue to delegate binary
+ownership to that package and must not duplicate its platform map, download
+client, verification keys, archive extraction, or cache manager.
+
+### R3. Free First-Run And Cached Flow
+
+With no license configured and a clean cache, the existing documented command
+must download the signed Free Windows ARM64 archive, verify it, extract it,
+forward its executable path to Playwright MCP, and complete a browser action.
+No new flag or environment variable may be required. Later starts may reuse the
+verified native cache.
+
+### R4. Pro First-Run And Cached Flow
+
+With a valid Pro license supplied through the existing CloakBrowser contract,
+the same default bridge flow must download, verify, cache, and launch the native
+Pro Windows ARM64 executable. A valid Pro request must not silently fall back to
+the Free or Windows x64 binary. Later starts may reuse the verified native Pro
+cache according to existing update and version-pin behavior.
+
+### R5. Transparent Cache Transition
+
+An existing Windows x64 executable cached for the same Chromium version must
+not be mistaken for a native ARM64 executable after the user switches from x64
+Node.js to native ARM64 Node.js. The upstream dependency must isolate caches by
+platform or validate the executable architecture and replace the incompatible
+entry automatically. Users must not be required to delete the cache manually,
+and unrelated valid cache entries must not be destructively removed.
+
+### R6. Diagnostics
+
+The existing `doctor` command and `cloakbrowser_binary_info` tool must report
+the resolved `windows-arm64` platform, tier, version, cache path, binary path,
+and installation state through their existing output shapes. A failed
+resolution must produce an actionable error without disclosing a license or
+other credential.
+
+### R7. Failure, Integrity, And Cleanup
+
+Free and Pro ARM64 archives must use the existing detached-signature and
+checksum verification path. Missing manifests, invalid signatures, checksum
+mismatches, corrupt archives, wrong-architecture executables, and
+non-executable results must fail closed. The bridge must not launch an
+unverified binary, an x64 fallback, or an unrelated browser.
+
+Concurrent or interrupted first starts must not leave a partial, unverified, or
+wrong-architecture cache entry marked as installed. Existing bridge cleanup of
+temporary runtime state must continue after configuration failure.
+
+### R8. Public Interface Stability
+
+This change must not add or change CLI flags, environment variables, MCP tool
+names, tool schemas, server metadata, stdio behavior, Streamable HTTP behavior,
+or upstream Playwright MCP browser contracts. The two local introspection tools
+remain the only local tools.
+
+### R9. Existing Compatibility
+
+Linux x64/arm64, macOS x64/arm64, Windows x64, Docker
+`linux/amd64`/`linux/arm64`, both MCP transports, and all currently supported
+Node.js versions must retain their existing behavior. No existing supported
+platform may resolve a different platform tag or archive because Windows ARM64
+was added.
+
+### R10. Native Free CI Gate
+
+The normal quality and package-verification suites must run on GitHub's native
+`windows-11-arm` runner for the full supported Node.js matrix. A separate
+default-engine smoke on that runner must use a packaged candidate, a clean
+cache, and a local test page to prove all of the following:
+
+- Node.js reports `win32` and `arm64`;
+- the Free archive passes signature and checksum verification;
+- the resolved PE executable has ARM64 machine type `0xAA64`;
+- the default bridge launches that executable and completes a browser action;
+- `cloakbrowser_binary_info` reports platform `windows-arm64`, tier `free`, and
+  `installed: true`; and
+- a second start can reuse the verified native cache.
+
+The cache-transition case in R5 must also be automated by seeding an
+incompatible Windows x64 entry and proving that a native start reaches a
+verified ARM64 executable without a manual purge.
+
+### R11. Protected Pro CI Gate
+
+Native Pro validation must run on `windows-11-arm` only in a protected,
+non-fork workflow context. The existing repository secret used for this check
+must be unavailable to untrusted pull-request code, masked from logs, omitted
+from command arguments where it could be printed, and excluded from uploaded
+artifacts.
+
+With a clean Pro cache, the check must prove the authenticated archive is
+signature- and checksum-verified, its PE machine type is `0xAA64`,
+`cloakbrowser_binary_info` reports `windows-arm64` and tier `pro`, and the
+default bridge completes a browser action without falling back to Free.
+Workflow permissions must remain least-privilege.
+
+### R12. Compatibility Documentation
+
+Windows ARM64 may be advertised only after R10 and R11 pass. The compatibility
+source data and generated README/documentation tables must add Windows ARM64,
+and the testing documentation must describe the native runner and gates.
+Changed human-authored public documentation must be updated surgically in all
+required locales, with the relevant translation-manifest entries refreshed
+from the actual files.
+
+Documentation validation must include:
+
+- `npm run docs:compatibility:check`;
+- `npm run docs:build`;
+- `npm run docs:seo:validate`;
+- `npm run docs:translations:check`; and
+- `npm run check`.
+
+### R13. Rollback
+
+If the selected stable upstream release is withdrawn or fails either native
+gate, the dependency floor, Windows ARM64 CI inclusion, and public support claim
+must be reverted together. Rollback must not delete user caches or alter
+existing platform behavior.
+
+## Constraints And Defaults
+
+- Stable upstream support is mandatory; prerelease packages and bridge-local
+  binary logic are excluded.
+- Native ARM64 is mandatory; Windows x64 emulation is not a fallback.
+- Both Free and Pro paths are mandatory before the public platform claim.
+- The existing Node.js engine range, binary update controls, version-pin
+  behavior, local binary override, logging destinations, and transport
+  boundaries remain unchanged.
+- No new telemetry, user-data processing, retention policy, credential format,
+  or secret is introduced.
+
+## Non-Goals
+
+- Building, signing, or publishing CloakBrowser artifacts from this repository.
+- Specifying or implementing changes in the upstream CloakBrowser repository.
+- Adding a Windows container image or changing the existing Linux Docker
+  platforms.
+- Detecting the host CPU behind an x64 Node.js process.
+- Adding a platform-specific CLI option, environment alias, MCP tool, or browser
+  contract.
+- Performing a project version bump, release, publication, commit, push, or pull
+  request as part of this specification workflow.
+
+## Acceptance Criteria
+
+1. The selected stable upstream package satisfies every R2 prerequisite, and
+   the dependency lower bound and lockfile resolve to that version or newer
+   compatible stable versions.
+2. The public `windows-11-arm` matrix passes the existing quality and package
+   suites on every supported Node.js version.
+3. The clean-cache Free smoke, warm-cache Free smoke, PE architecture check,
+   local browser action, diagnostics assertions, and x64-to-ARM64 cache
+   transition in R10 pass.
+4. The protected Pro smoke in R11 passes without exposing its credential in
+   logs, process arguments, caches committed to the repository, or artifacts.
+5. Negative verification coverage proves a missing or invalid signed manifest,
+   checksum mismatch, corrupt archive, and wrong-architecture cached executable
+   cannot be launched or reported as installed.
+6. Existing platform matrices, unit/integration/E2E suites, package
+   verification, upstream tool parity, and both transport contracts remain
+   green and unchanged.
+7. `doctor` and `cloakbrowser_binary_info` expose the native platform through
+   their existing contracts, and the public/localized compatibility
+   documentation passes every R12 validation command.
+
+## Evidence
+
+- Repository flow: `src/bridge/config.ts`, `src/bridge/tools.ts`, and
+  `src/cli/doctor.ts`.
+- Package contract: `package.json` and `package-lock.json`.
+- Current platform claims: `README.md`, `docs/testing.md`,
+  `docs/version-compatibility.md`, and
+  `docs/data/version-compatibility.json`.
+- Current CI matrix: `.github/workflows/ci.yml`.
+- User report: [issue #89](https://github.com/swimmwatch/cloakbrowser-mcp/issues/89).
+- Upstream API and platform documentation:
+  `https://github.com/CloakHQ/cloakbrowser/blob/main/_autodocs/api-reference/javascript-launch.md`
+  and `https://github.com/CloakHQ/cloakbrowser/blob/main/js/README.md`.
+- Native runner availability:
+  `https://github.com/github/docs/blob/main/data/reusables/actions/supported-github-runners.md`.

--- a/docs/specs/win32-arm64-support/tasks/01_qualify_upstream_release.md
+++ b/docs/specs/win32-arm64-support/tasks/01_qualify_upstream_release.md
@@ -1,0 +1,188 @@
+# Packet 01 — Qualify The Stable Upstream Release
+
+## Outcome
+
+Identify one exact stable `cloakbrowser` version that satisfies the complete
+consumer prerequisite, and record enough evidence for another maintainer to
+reproduce the decision. If no release qualifies, record the check and stop
+without changing package metadata or implementation files.
+
+## Prerequisites And Dependencies
+
+- The specification is `Status: Approved`.
+- No earlier packet is required.
+- Public npm and upstream release metadata must be reachable.
+- Pro artifact evidence may require the protected credential gate below.
+
+## Owned Requirements
+
+- R2 Stable Upstream Dependency Gate
+- R4 Pro First-Run And Cached Flow, for upstream artifact availability
+- R5 Transparent Cache Transition, for upstream cache semantics
+- R7 Failure, Integrity, And Cleanup, for upstream integrity semantics
+- R13 Rollback, for withdrawal criteria
+
+## Scope
+
+For a candidate stable version `V`:
+
+1. Confirm `V` is published under a stable npm dist-tag, not a prerelease, and
+   record its version, tarball URL, npm integrity, and source revision.
+2. Inspect the published tarball/source and authoritative release metadata to
+   confirm that `win32` plus `arm64` maps to `windows-arm64` and
+   `cloakbrowser-windows-arm64.zip`.
+3. Confirm `binaryInfo()` reports coherent Windows ARM64 platform, tier,
+   version, cache directory, binary path, installation state, and download URL
+   through the existing API.
+4. Confirm the Free Windows ARM64 archive exists and is covered by the normal
+   detached-signature and checksum verification chain.
+5. Confirm the authenticated Pro path exposes a native Windows ARM64 archive
+   covered by its normal signed manifest, with no Free or x64 fallback.
+6. Confirm the cache layout isolates platforms or validates PE architecture so
+   a same-version x64 cache entry is transparently replaced without deleting
+   unrelated valid caches.
+7. Record upstream evidence for missing/invalid signed manifests, checksum
+   mismatch, corrupt archives, interrupted/concurrent acquisition, and
+   wrong-architecture cache rejection. Absence of objective upstream evidence
+   blocks qualification; do not add bridge-local verification logic.
+
+Write the exact evidence and accepted version into this packet's
+`Qualification Record` and into `handoff.md`. Normalize the accepted version in
+`decisions.yaml` as a new observed implementation decision.
+
+## Non-Goals
+
+- Do not fork, patch, build, sign, upload, or publish CloakBrowser.
+- Do not accept prerelease, Git URL, vendored tarball, or local path
+  dependencies.
+- Do not download or store a credential in the repository.
+- Do not edit `package.json`, the lockfile, source, tests, workflows, or public
+  compatibility documentation.
+
+## Relevant Contracts
+
+- Native acceptance is PE machine type `0xAA64`; an x64 archive or emulated
+  launch is rejection.
+- Free and Pro are both mandatory.
+- The signed manifest/checksum path must be the existing upstream trust path.
+- No bridge-local platform map, downloader, key, extractor, or cache manager is
+  permitted.
+- Withdrawal, signature failure, or either native gate failing invalidates `V`
+  and triggers the coordinated R13 rollback.
+
+## Expected Files
+
+- `docs/specs/win32-arm64-support/decisions.yaml`
+- `docs/specs/win32-arm64-support/tasks/01_qualify_upstream_release.md`
+- `docs/specs/win32-arm64-support/tasks/todo.md`
+- `docs/specs/win32-arm64-support/tasks/handoff.md`
+
+No other file is owned by this packet.
+
+## Objective Acceptance
+
+- One exact stable version `V` satisfies every numbered scope check.
+- Every claim names a public URL, immutable package integrity/source revision,
+  upstream test reference, or protected check result.
+- Evidence distinguishes Free from Pro and native ARM64 from x64.
+- No secret value, secret-derived URL, authorization header, or private
+  manifest content is recorded.
+- If no release qualifies, this packet remains unchecked and its latest
+  observation is recorded as the blocker.
+
+## Verification
+
+Focused read-only commands:
+
+```bash
+npm view cloakbrowser dist-tags versions --json
+npm view cloakbrowser@<V> version dist.integrity dist.tarball gitHead --json
+npm pack cloakbrowser@<V> --json --pack-destination <temporary-directory>
+npm run upstream:check:cloakbrowser
+```
+
+Use a directory created by `mktemp -d` for the tarball and remove only that
+explicit directory after recording non-sensitive evidence. Inspect the
+published package and upstream signed release metadata; do not mutate the
+installed project dependency during qualification.
+
+Repository-level checks for the Markdown/YAML evidence:
+
+```bash
+npx prettier --check docs/specs/win32-arm64-support
+npm run docs:build
+npm run docs:translations:check
+```
+
+If the translation command fails only for the recorded DeepL deferral, record
+the exact failure and do not claim it passed.
+
+## Failure, Rollback, And Recovery
+
+- Reject a candidate on any missing Free, Pro, signature, checksum,
+  diagnostics, cache, or native-architecture property.
+- A read-only rejected candidate requires no code rollback. Record the version
+  and reason so it is not re-evaluated without new upstream evidence.
+- Never delete the user's normal CloakBrowser cache. Qualification uses only
+  explicit temporary paths.
+
+## Manual Gates
+
+- **MANUAL GATE — protected Pro qualification:** if public metadata is
+  insufficient, a maintainer must authorize and supply an existing credential
+  only to the protected process. Never ask for or persist its value.
+- **MANUAL GATE — external mutation:** opening upstream issues, publishing
+  artifacts, or changing upstream state is outside this packet and needs
+  separate authorization.
+
+## Completion Checklist
+
+- [ ] Stable `V` and immutable npm metadata recorded.
+- [ ] Windows ARM64 mapping and archive name confirmed.
+- [ ] Free signed archive and integrity path confirmed.
+- [ ] Pro native archive and non-fallback integrity path confirmed.
+- [ ] `binaryInfo()` Windows ARM64 output confirmed.
+- [ ] Cache transition and negative integrity evidence confirmed.
+- [x] Decision ledger reviewed and handoff updated without sensitive data.
+- [x] Focused checks recorded.
+- [ ] `todo.md` packet link checked only if every acceptance item passes.
+
+## Qualification Record
+
+Observed on 2026-07-25:
+
+- Candidate version: `cloakbrowser@0.5.2` (rejected; it is not an accepted
+  `V`).
+- Stable dist-tag: npm `latest` points to `0.5.2`, and no newer published
+  version exists.
+- npm integrity:
+  `sha512-vXMWM1HzI87CGUrOobMpTu/GqPn2eZbNcImhMMjF/48/M12iZEWVolrquY3ot0YI++ddYjoVb71hkodpRsRlIg==`;
+  tarball
+  `https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.5.2.tgz`;
+  SHA-1 `39c870727a9187ca506e053c020cff78340f2701`.
+- Source revision: `a5f2c33ff9aa27cabd93871d714ee1469fb8fcc5`.
+- Free archive and signed-manifest evidence: the published tarball's
+  `dist/config.js` maps only `win32-x64` to `windows-x64`; it has no
+  `win32-arm64` or `windows-arm64` mapping. GitHub release
+  `chromium-v146.0.7680.177.5` publishes
+  `cloakbrowser-linux-x64.tar.gz`, `cloakbrowser-windows-x64.zip`,
+  `SHA256SUMS`, and `SHA256SUMS.sig`, but no
+  `cloakbrowser-windows-arm64.zip`.
+- Pro archive and signed-manifest evidence: not evaluated and no credential was
+  requested. The candidate already fails the mandatory public package mapping
+  and Free archive gates.
+- `binaryInfo()` evidence: not runnable for the required platform because the
+  published platform resolver rejects `win32-arm64` before it can return
+  coherent `windows-arm64` information.
+- Cache transition evidence: not evaluated because the candidate has no native
+  Windows ARM64 platform mapping or archive.
+- Negative integrity/concurrency evidence: not evaluated because the candidate
+  already fails mandatory R2 prerequisites.
+- Qualification result: rejected. Packet 01 remains incomplete, and packet 02
+  is ineligible until a newer stable upstream release is requalified.
+
+## Handoff
+
+Record the accepted `V`, evidence locations, checks, and remaining manual gates
+in `handoff.md`. The only next eligible packet after successful qualification
+is packet 02.

--- a/docs/specs/win32-arm64-support/tasks/02_consume_upstream_dependency.md
+++ b/docs/specs/win32-arm64-support/tasks/02_consume_upstream_dependency.md
@@ -1,0 +1,132 @@
+# Packet 02 — Consume The Upstream Dependency
+
+## Outcome
+
+Raise the `cloakbrowser` dependency lower bound and lockfile to the exact stable
+version qualified in packet 01 while preserving the thin bridge and all
+existing public behavior.
+
+## Prerequisites And Dependencies
+
+- Packet 01 is complete.
+- Its qualification record names the exact accepted stable version `V`.
+- No unresolved withdrawal or integrity warning applies to `V`.
+
+## Owned Requirements
+
+- R2 Stable Upstream Dependency Gate
+- R8 Public Interface Stability
+- R9 Existing Compatibility
+- R13 Rollback
+
+## Scope
+
+- Change the direct `cloakbrowser` dependency range so its minimum is exactly
+  `V` and older unsupported versions cannot resolve.
+- Regenerate `package-lock.json` with npm so the root dependency declaration
+  matches `package.json` and the locked package satisfies the new range.
+- Preserve the existing semver compatibility style unless `V` itself requires
+  a different stable-major boundary.
+- Verify existing bridge configuration, doctor, and local tool code continue to
+  delegate to upstream APIs without platform-specific branches.
+
+## Non-Goals
+
+- No source, test, workflow, Docker, public documentation, package-version, or
+  release change.
+- No prerelease, fork, Git, file, override, or vendored dependency.
+- No bridge-local platform mapping, download, verification, extraction, cache,
+  or fallback logic.
+- No CLI, environment, MCP, HTTP, process, logging, or upstream tool-contract
+  change.
+
+## Relevant Contracts
+
+- `package.json` remains the direct dependency authority and
+  `package-lock.json` must be reproducible with `npm ci`.
+- Existing Node engine range `^22.13.0 || >=24.0.0` is unchanged.
+- Existing Linux, macOS, Windows x64, Docker, stdio, Streamable HTTP, doctor,
+  and local tool behavior must remain unchanged.
+- Rollback restores the previous dependency declaration and lockfile together;
+  it never deletes cache data.
+
+## Expected Files
+
+- `package.json`
+- `package-lock.json`
+- Packet/checklist/handoff state under
+  `docs/specs/win32-arm64-support/tasks/`
+
+No runtime source file is expected to change. Stop if the dependency cannot be
+consumed without a runtime bridge edit and return the conflict to specification
+review.
+
+## Objective Acceptance
+
+- The direct range's lower bound is exactly qualified `V`.
+- The lockfile root declaration matches and the installed
+  `cloakbrowser` version satisfies the range.
+- `npm ci --ignore-scripts` succeeds from the lockfile.
+- Package verification and the existing repository suites pass, subject only
+  to a separately recorded translation-service blocker.
+- A diff inspection shows no platform logic or public interface change.
+
+## Verification
+
+Focused checks:
+
+```bash
+npm ci --ignore-scripts
+npm ls cloakbrowser
+npm run upstream:check:cloakbrowser
+npm run package:verify
+git diff -- package.json package-lock.json
+```
+
+Repository checks:
+
+```bash
+npm run typecheck
+npm run lint
+npm run format:check
+npm test
+npm run test:integration
+npm run test:e2e:run
+npm run check
+```
+
+Run and record `npm run check`. If it fails only because the existing
+specification/planning localizations are blocked by DeepL quota, record that
+exact known failure and the passing component commands; do not report the full
+check as passed.
+
+## Failure, Rollback, And Recovery
+
+- If installation, lockfile reproducibility, package verification, or existing
+  compatibility fails, restore only this packet's dependency and lockfile
+  changes and leave prior user changes untouched.
+- If `V` is withdrawn or its integrity changes, mark packet 01 invalid and stop.
+- Do not clear any user or CI CloakBrowser cache as recovery.
+
+## Manual Gates
+
+- No external mutation is required for this packet.
+- Commit, push, PR, publication, and release remain separate
+  **MANUAL GATE** actions and are not authorized.
+
+## Completion Checklist
+
+- [ ] Packet 01 version copied exactly.
+- [ ] `package.json` lower bound raised.
+- [ ] `package-lock.json` regenerated reproducibly.
+- [ ] No runtime or public interface changes introduced.
+- [ ] Focused checks recorded.
+- [ ] Repository checks recorded truthfully.
+- [ ] Handoff updated.
+- [ ] `todo.md` packet link checked.
+
+## Handoff
+
+Record `V`, the resolved lockfile version/integrity, exact changed files, and
+all check results in `handoff.md`. The only next eligible packet is packet 03.
+

--- a/docs/specs/win32-arm64-support/tasks/03_add_native_windows_smoke_harness.md
+++ b/docs/specs/win32-arm64-support/tasks/03_add_native_windows_smoke_harness.md
@@ -1,0 +1,205 @@
+# Packet 03 — Add The Native Windows ARM64 Smoke Harness
+
+## Outcome
+
+Add an opt-in packaged-candidate E2E harness that runs the real upstream
+Playwright MCP bridge with the default CloakBrowser engine on native Windows
+ARM64 and independently proves the required Free and Pro flows.
+
+## Prerequisites And Dependencies
+
+- Packet 02 is complete and installs the stable qualified dependency.
+- The executor has a native Windows ARM64 environment for acceptance.
+- The Free smoke requires network access to signed public artifacts.
+- The Pro smoke requires a credential only through the manual gate below.
+
+## Owned Requirements
+
+- R1 Supported Platform
+- R3 Free First-Run And Cached Flow
+- R4 Pro First-Run And Cached Flow
+- R5 Transparent Cache Transition
+- R6 Diagnostics
+- R7 Failure, Integrity, And Cleanup
+- R8 Public Interface Stability
+- R10 Native Free CI Gate, for its executable harness
+- R11 Protected Pro CI Gate, for its executable harness
+
+## Scope
+
+Create separate Free and Pro manual E2E entry points backed by shared helpers:
+
+- Pack the current repository with `npm pack`, install the tarball into a
+  temporary project, and invoke its installed `cloakbrowser-mcp` executable.
+- Require and assert `process.platform === "win32"` and
+  `process.arch === "arm64"` before any acceptance scenario.
+- Use the installed package's real `@playwright/mcp` child and leave
+  `PLAYWRIGHT_MCP_BROWSER_ENGINE` and `PLAYWRIGHT_MCP_CLI_PATH` unset. The
+  existing fake-upstream distribution E2E remains unchanged.
+- Serve a deterministic page from a loopback-only Node HTTP server, call the
+  existing upstream browser tools through stdio MCP, and prove a browser action
+  against that page.
+- Set `CLOAKBROWSER_CACHE_DIR` to a test-owned `tmpdir()` directory. Clean up
+  only paths created by the test.
+- Inspect the resolved executable from the existing
+  `cloakbrowser_binary_info` result. Validate DOS `MZ`, PE signature, and the
+  little-endian COFF Machine field at `e_lfanew + 4`; it must equal `0xAA64`.
+
+The Free entry point must:
+
+1. remove `CLOAKBROWSER_LICENSE_KEY` from the child environment;
+2. start from a clean cache, resolve the signed Free binary, launch it, perform
+   the loopback browser action, and assert diagnostics report
+   `windows-arm64`, tier `free`, and `installed: true`;
+3. start a second bridge with the same cache, prove the same verified native
+   binary is reused, and repeat the browser action;
+4. seed a same-version x64 PE cache entry using the qualified upstream
+   package's own `binaryInfo()` paths for fixture placement, then prove a native
+   start replaces or isolates it without a manual purge and without removing an
+   unrelated sentinel cache entry;
+5. exercise concurrent clean-cache starts and a partial/unverified cache
+   fixture, proving no partial or wrong-architecture executable is treated as
+   installed.
+
+The Pro entry point must:
+
+1. read the existing `CLOAKBROWSER_LICENSE_KEY` only from its process
+   environment and fail generically if absent;
+2. use a distinct clean temporary cache, resolve Pro without Free fallback,
+   launch it, perform the browser action, and assert diagnostics report
+   `windows-arm64`, tier `pro`, and `installed: true`;
+3. repeat with the warm Pro cache;
+4. collect child stderr only for assertions, verify it does not contain the
+   exact credential, and redact the value before constructing any failure
+   message.
+
+Add explicit package scripts for the two manual entry points. They are CI-facing
+test scripts, not public runtime environment or CLI contracts.
+
+## Non-Goals
+
+- Do not change bridge runtime code or duplicate upstream platform/download
+  logic in production.
+- Do not modify upstream browser tool names or schemas.
+- Do not make real binary downloads part of the default local `npm test` or
+  fake-upstream distribution suites.
+- Do not use the system CloakBrowser cache, a remote test page, x64 emulation,
+  `CLOAKBROWSER_BINARY_PATH`, or the Playwright fallback engine.
+- Do not log, persist, snapshot, upload, or pass a Pro credential as a command
+  argument.
+
+## Relevant Contracts
+
+- The runtime remains a thin stdio/HTTP bridge; the smoke uses stdio only to
+  prove the packaged default launch path.
+- Existing local tool output shapes are asserted, not changed.
+- The test may import the packaged `cloakbrowser` dependency for fixture path
+  discovery only; production code must not reproduce its cache layout.
+- All test files and caches live under unique `tmpdir()` roots and are removed
+  in `finally`/cleanup hooks.
+- Missing manifest, invalid signature, checksum mismatch, and corrupt archive
+  rejection remain upstream-owned and must already be evidenced by packet 01.
+  This packet adds consumer evidence for partial, concurrent, and
+  wrong-architecture cache behavior.
+
+## Expected Files
+
+- `package.json`
+- `tests/e2e/windowsArm64NativeHarness.ts`
+- `tests/e2e/windows-arm64-free.manual.ts`
+- `tests/e2e/windows-arm64-pro.manual.ts`
+- Existing E2E helpers only if a small reusable extraction is necessary
+- Packet/checklist/handoff state under
+  `docs/specs/win32-arm64-support/tasks/`
+
+Prefer the existing `vitest.distribution-e2e.config.mjs`; add no new config
+unless the current manual-test include and timeouts cannot express the native
+smokes. Do not rewrite `tests/e2e/distributionHarness.ts` around the real
+browser path.
+
+## Objective Acceptance
+
+- The two scripts target distinct Free and Pro entry points.
+- A non-Windows or non-ARM64 run fails clearly and cannot produce a false pass.
+- Free clean, Free warm, Pro clean, Pro warm, loopback browser actions,
+  diagnostics, and `0xAA64` PE checks pass on native Windows ARM64.
+- The x64 cache fixture is not launched or reported installed, requires no
+  manual purge, and does not erase the unrelated sentinel.
+- Concurrent/partial-cache coverage leaves only a verified ARM64 executable.
+- Pro never falls back to Free, and captured output/failures contain no
+  credential.
+- Existing fake-upstream packaged E2E and public interfaces are unchanged.
+
+## Verification
+
+Focused platform-neutral checks:
+
+```bash
+npm run typecheck
+npm run lint
+npm run format:check
+npm run test:e2e:npm-package
+```
+
+Focused native Windows ARM64 checks:
+
+```bash
+npm run test:e2e:windows-arm64:free
+npm run test:e2e:windows-arm64:pro
+```
+
+The Pro command is run only inside an approved protected process with
+`CLOAKBROWSER_LICENSE_KEY` in the process environment. Do not include the value
+in a command line or report.
+
+Repository checks:
+
+```bash
+npm run package:verify
+npm test
+npm run test:integration
+npm run check
+```
+
+Record environment-dependent commands as not run unless they actually ran on
+native hardware. The known translation-service failure may be recorded as in
+packet 02, but no other failure is waived.
+
+## Failure, Rollback, And Recovery
+
+- On any test failure, close MCP clients, stop the loopback server and child
+  processes, and remove only explicit test temp roots.
+- Never call the upstream global cache-clear operation against the default
+  cache.
+- If the qualified upstream API cannot support isolated fixtures without
+  production duplication, stop and return the conflict to packet 01/spec
+  review.
+- Rollback removes only the new scripts and E2E files; the packet 02 dependency
+  remains until a coordinated R13 rollback is authorized.
+
+## Manual Gates
+
+- **MANUAL GATE — Pro credential:** make the existing credential available only
+  in a protected process environment. Never request or persist its value.
+- Commit, push, PR, workflow execution, publication, and release are separate
+  **MANUAL GATE** actions and are not authorized.
+
+## Completion Checklist
+
+- [ ] Shared packaged-candidate native harness added.
+- [ ] Free clean/warm and loopback action covered.
+- [ ] Pro clean/warm and no-fallback action covered.
+- [ ] PE `0xAA64` and existing diagnostics asserted.
+- [ ] x64 transition, sentinel preservation, concurrency, and partial cache covered.
+- [ ] Credential redaction and temp/process cleanup covered.
+- [ ] Existing fake-upstream distribution E2E remains green.
+- [ ] Focused and repository checks recorded.
+- [ ] Handoff updated.
+- [ ] `todo.md` packet link checked.
+
+## Handoff
+
+Record the exact script names, files, native environment, cache scenarios,
+credential-safety result, and all command outcomes in `handoff.md`. Packets 04
+and 05 become independently eligible after this packet.
+

--- a/docs/specs/win32-arm64-support/tasks/04_wire_public_windows_arm_ci.md
+++ b/docs/specs/win32-arm64-support/tasks/04_wire_public_windows_arm_ci.md
@@ -1,0 +1,148 @@
+# Packet 04 — Wire Public Windows ARM64 CI
+
+## Outcome
+
+Run the existing quality/package suites across the full supported Node.js
+matrix on GitHub's native Windows ARM64 runner and add a separate public Free
+default-engine smoke.
+
+## Prerequisites And Dependencies
+
+- Packet 03 is complete.
+- `npm run test:e2e:windows-arm64:free` passes on native Windows ARM64.
+- GitHub still exposes the public-repository runner label `windows-11-arm`.
+
+## Owned Requirements
+
+- R1 Supported Platform
+- R3 Free First-Run And Cached Flow
+- R5 Transparent Cache Transition
+- R6 Diagnostics
+- R9 Existing Compatibility
+- R10 Native Free CI Gate
+- R13 Rollback
+
+## Scope
+
+Update `.github/workflows/ci.yml`:
+
+- Add `windows-11-arm` to the existing `quality` operating-system matrix so
+  `npm run check` and `npm run package:verify` run for Node.js
+  `22`, `24`, `25`, and `26`, as derived from `NODE_CHECK_VERSIONS`.
+- Add one dedicated `windows-11-arm` Free smoke job using native Node.js 24.
+  It installs with `npm ci --ignore-scripts` and runs
+  `npm run test:e2e:windows-arm64:free`.
+- Keep the Free job public and credential-free. It must not reference the Pro
+  secret, persist the CloakBrowser cache across jobs, or upload the downloaded
+  binary.
+- Preserve top-level `permissions: contents: read`, existing concurrency,
+  pinned action SHAs/comments, and all existing jobs/matrices.
+- Give the real-download smoke a bounded timeout that accommodates the signed
+  archive download without weakening other job timeouts.
+
+The Free test itself owns clean/warm/cache-transition assertions inside an
+isolated job-local temp path; the workflow must not prepopulate that path.
+
+## Non-Goals
+
+- Do not add the Pro credential or Pro job here.
+- Do not add Windows Docker, self-hosted runners, x64 emulation, artifact
+  uploads, dependency caching beyond existing npm setup, or a browser cache
+  shared across runs.
+- Do not change release, deployment, documentation, or repository settings.
+- Do not reduce the existing Linux, macOS, Windows x64, Node, package,
+  coverage, docs, Docker, security, or parity coverage.
+
+## Relevant Contracts
+
+- The exact native runner label is `windows-11-arm`.
+- The quality matrix covers every Node version from
+  `NODE_CHECK_VERSIONS`; the Free browser smoke runs once on native Node 24.
+- The default engine must remain CloakBrowser; the smoke cannot set Playwright
+  fallback or fake-upstream variables.
+- Workflow permissions stay least-privilege and all external actions stay
+  pinned by full SHA with readable version comments.
+
+## Expected Files
+
+- `.github/workflows/ci.yml`
+- Packet/checklist/handoff state under
+  `docs/specs/win32-arm64-support/tasks/`
+
+No test or runtime file is owned by this packet. If packet 03 changes are
+insufficient, stop and return to a separately authorized packet 03 fix.
+
+## Objective Acceptance
+
+- The expanded quality matrix has 24 combinations: six operating systems by
+  four Node versions, including native Windows ARM64.
+- The Free smoke is a distinct `windows-11-arm` job and runs the packaged,
+  default-engine test with no credential.
+- Existing matrix entries and jobs remain semantically unchanged.
+- Workflow syntax, action pinning, permissions, actionlint, and high-severity
+  zizmor checks pass.
+- No public support claim is added by this packet.
+
+## Verification
+
+Focused local checks:
+
+```bash
+npm run format:check
+npm run test:e2e:windows-arm64:free
+```
+
+The native smoke is recorded as not run unless executed on Windows ARM64.
+
+Workflow checks:
+
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
+python3 -m pipx run zizmor --min-severity high .
+```
+
+Repository checks:
+
+```bash
+npm run check
+git diff -- .github/workflows/ci.yml
+```
+
+Record the known translation-service blocker separately if it is the only full
+check failure. Workflow acceptance still requires actionlint and zizmor to
+pass.
+
+## Failure, Rollback, And Recovery
+
+- A missing runner label, architecture mismatch, or non-native execution is a
+  hard failure; do not substitute `windows-latest`.
+- Repeated upstream download failure is recorded and rerun later; it does not
+  justify caching or bypassing verification.
+- Rollback removes only the Windows ARM64 matrix entry and Free job. If the
+  accepted dependency is invalid, use the coordinated R13 rollback rather than
+  altering user caches.
+
+## Manual Gates
+
+- **MANUAL GATE — external CI:** observing the actual GitHub runner requires a
+  separately authorized push/PR or workflow dispatch handled in packet 06.
+- Commit, push, PR, merge, publication, and release remain separate
+  **MANUAL GATE** actions.
+
+## Completion Checklist
+
+- [ ] `windows-11-arm` added to the full Node quality matrix.
+- [ ] Dedicated public Free smoke job added.
+- [ ] No Pro secret, browser cache, or downloaded binary is persisted.
+- [ ] Permissions and pinned actions preserved.
+- [ ] Actionlint and zizmor pass.
+- [ ] Local/repository checks recorded.
+- [ ] Handoff updated.
+- [ ] `todo.md` packet link checked.
+
+## Handoff
+
+Record the matrix cardinality, Free job name, runner/Node selection, actionlint,
+zizmor, and repository results in `handoff.md`. Packet 06 remains blocked until
+packet 05 also completes.
+

--- a/docs/specs/win32-arm64-support/tasks/05_wire_protected_pro_ci.md
+++ b/docs/specs/win32-arm64-support/tasks/05_wire_protected_pro_ci.md
@@ -1,0 +1,164 @@
+# Packet 05 — Wire Protected Pro CI
+
+## Outcome
+
+Add a repeatable native Windows ARM64 Pro smoke that can receive a license only
+after protected-environment approval and can never expose it to fork pull
+requests, non-Pro steps, logs, arguments, caches, or artifacts.
+
+## Prerequisites And Dependencies
+
+- Packet 03 is complete.
+- `npm run test:e2e:windows-arm64:pro` passes in a protected native environment.
+- A maintainer has completed both manual gates below, including supplying the
+  exact non-sensitive secret identifier.
+- The selected protection model remains same-repository PR/manual CI with the
+  `windows-arm64-pro` GitHub Environment.
+
+## Owned Requirements
+
+- R1 Supported Platform
+- R4 Pro First-Run And Cached Flow
+- R6 Diagnostics
+- R7 Failure, Integrity, And Cleanup
+- R11 Protected Pro CI Gate
+- R13 Rollback
+
+## Scope
+
+Add a dedicated workflow for the Pro gate, expected at
+`.github/workflows/windows-arm64-pro.yml`, with these boundaries:
+
+- Triggers may support `pull_request` and `workflow_dispatch`; never use
+  `pull_request_target`.
+- A pull-request job is eligible only when the head repository equals the base
+  repository. Fork pull requests must skip before environment access.
+- Manual dispatch is limited to the repository's default/protected branch.
+- The job uses `runs-on: windows-11-arm`, native Node.js 24,
+  `environment: windows-arm64-pro`, bounded timeout, and least-privilege
+  `contents: read`.
+- Checkout, setup, `npm ci --ignore-scripts`, and build steps receive no Pro
+  secret.
+- Only the single smoke step maps the maintainer-supplied
+  `secrets.<IDENTIFIER>` to the existing process variable
+  `CLOAKBROWSER_LICENSE_KEY` and runs
+  `npm run test:e2e:windows-arm64:pro`.
+- The workflow does not echo environment variables, place the secret in a
+  command argument, persist the CloakBrowser cache, or upload logs/binaries.
+- External actions are pinned by full commit SHA with readable version
+  comments.
+
+The secret identifier is not `CLOAKBROWSER_LICENSE_KEY` unless a maintainer
+explicitly selects that non-sensitive identifier in a new Prompt MCP decision.
+Record the supplied identifier—not its value—as a new revision of
+`planning.pro-secret-identifier` before editing the workflow.
+
+## Non-Goals
+
+- Do not request, read back, store, validate, or print the credential value.
+- Do not create repository/environment secrets through code or CLI.
+- Do not run untrusted fork code with secrets, use `pull_request_target`, grant
+  write permissions, upload artifacts, share Pro caches, or fall back to Free.
+- Do not change public documentation, runtime interfaces, release workflows, or
+  repository protection settings from the worktree.
+
+## Relevant Contracts
+
+- Environment name is exactly `windows-arm64-pro`.
+- Secret expression uses the separately confirmed identifier and is scoped only
+  to the Pro smoke step as `CLOAKBROWSER_LICENSE_KEY`.
+- A missing secret fails generically without printing the identifier or value.
+- Protected-environment reviewers are the approval boundary for same-repository
+  PR code and manual default-branch execution.
+- Job permissions remain `contents: read`; no credential-bearing artifact is
+  produced.
+
+## Expected Files
+
+- `.github/workflows/windows-arm64-pro.yml`
+- `docs/specs/win32-arm64-support/decisions.yaml`, only for the non-sensitive
+  secret identifier decision revision
+- Packet/checklist/handoff state under
+  `docs/specs/win32-arm64-support/tasks/`
+
+No runtime or test file is owned by this packet.
+
+## Objective Acceptance
+
+- Fork PRs cannot reach the protected environment or secret expression.
+- Same-repository PR/manual runs require `windows-arm64-pro` approval.
+- Only the smoke step receives the mapped credential.
+- The Pro harness proves signed native Pro resolution, PE `0xAA64`,
+  `windows-arm64`/`pro` diagnostics, browser action, warm cache, and no Free
+  fallback.
+- Workflow permissions, action pins, syntax, actionlint, and high-severity
+  zizmor checks pass.
+- No secret value or credential-bearing artifact is present in the diff or
+  task records.
+
+## Verification
+
+Focused protected check:
+
+```bash
+npm run test:e2e:windows-arm64:pro
+```
+
+Run only in a protected native Windows ARM64 process with the credential in its
+environment.
+
+Workflow checks:
+
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
+python3 -m pipx run zizmor --min-severity high .
+npm run format:check
+npm run check
+git diff -- .github/workflows/windows-arm64-pro.yml
+```
+
+Inspect the diff for secret scope and prohibited triggers. Do not search or
+print the process environment.
+
+## Failure, Rollback, And Recovery
+
+- If the identifier or environment is unavailable, leave this packet unchecked
+  and stop; do not invent a placeholder expression.
+- If fork filtering, environment protection, or step scoping cannot be proven,
+  remove the workflow and redesign before any protected run.
+- A failed Pro smoke never falls back to Free and blocks packets 06 and 07.
+- Rollback deletes the dedicated workflow and coordinates dependency/public
+  claim rollback under R13; it does not delete user caches or environment
+  secrets.
+
+## Manual Gates
+
+- **MANUAL GATE — secret identifier:** a maintainer must supply the exact
+  non-sensitive GitHub secret identifier through Prompt MCP. The current
+  decision is `defer-binding`; this packet is blocked until revised.
+- **MANUAL GATE — repository settings:** a maintainer must create/configure the
+  `windows-arm64-pro` Environment, required reviewers, allowed default branch,
+  and access to the separately confirmed existing secret. Record only
+  completion, never the value.
+- **MANUAL GATE — protected execution:** each Pro run requires reviewer
+  approval.
+- Commit, push, PR, merge, publication, and release remain separate
+  **MANUAL GATE** actions.
+
+## Completion Checklist
+
+- [ ] Secret identifier decision revised through Prompt MCP.
+- [ ] `windows-arm64-pro` environment setup confirmed without credential data.
+- [ ] Dedicated workflow added without `pull_request_target`.
+- [ ] Fork and manual-ref guards implemented.
+- [ ] Credential scoped only to the Pro smoke step.
+- [ ] No cache/log/binary artifacts uploaded.
+- [ ] Actionlint, zizmor, focused, and repository checks recorded.
+- [ ] Handoff updated.
+- [ ] `todo.md` packet link checked.
+
+## Handoff
+
+Record the non-sensitive identifier, environment-policy confirmation, workflow
+job name, trigger guards, checks, and remaining protected-run approval in
+`handoff.md`. Packet 06 becomes eligible only after packet 04 is also complete.

--- a/docs/specs/win32-arm64-support/tasks/06_validate_native_ci.md
+++ b/docs/specs/win32-arm64-support/tasks/06_validate_native_ci.md
@@ -1,0 +1,172 @@
+# Packet 06 — Validate Native CI
+
+## Outcome
+
+Run the implemented workflows on GitHub, record immutable native Windows ARM64
+quality, Free, and protected Pro evidence, and establish whether the
+compatibility claim may proceed.
+
+## Prerequisites And Dependencies
+
+- Packets 04 and 05 are complete.
+- A branch/commit containing packets 02–05 exists on GitHub through separately
+  authorized delivery work.
+- The `windows-arm64-pro` Environment, required reviewers, allowed ref, and
+  confirmed secret identifier are configured.
+- The stable upstream release remains available and unwithdrawn.
+
+## Owned Requirements
+
+- R1 Supported Platform
+- R3 Free First-Run And Cached Flow
+- R4 Pro First-Run And Cached Flow
+- R5 Transparent Cache Transition
+- R6 Diagnostics
+- R7 Failure, Integrity, And Cleanup
+- R9 Existing Compatibility
+- R10 Native Free CI Gate
+- R11 Protected Pro CI Gate
+- R13 Rollback
+
+## Scope
+
+Using the same immutable commit SHA:
+
+1. Run the normal CI workflow and confirm every existing job remains green.
+2. Confirm all four `windows-11-arm` quality cells run on native ARM64 and pass
+   `npm run check` plus `npm run package:verify`.
+3. Confirm the public Free job runs on `windows-11-arm` and records passing
+   clean-cache, warm-cache, PE `0xAA64`, loopback browser action,
+   `windows-arm64`/`free` diagnostics, x64-cache transition, partial-cache, and
+   concurrent-start assertions.
+4. Obtain protected-environment approval and run the Pro workflow for the same
+   SHA. Confirm clean/warm Pro, signed acquisition, PE `0xAA64`, loopback
+   action, `windows-arm64`/`pro` diagnostics, and no Free fallback.
+5. Inspect workflow summaries and failure logs for architecture and result
+   evidence. Confirm the Pro credential is absent from logs, process arguments,
+   annotations, caches, and artifacts without printing or retrieving its value.
+6. Record workflow URLs, run IDs, commit SHA, event/ref, runner labels, Node
+   versions, job conclusions, and rerun attempts in `handoff.md` and this
+   packet's `Native CI Record`.
+
+Do not edit production code in this packet. A failure routes back to the
+smallest owning packet under separate authorization.
+
+## Non-Goals
+
+- Do not merge, publish, release, update public compatibility documentation, or
+  change repository settings.
+- Do not accept local-only, x64-emulated, cancelled, skipped, neutral, or
+  partially successful evidence.
+- Do not download workflow artifacts containing binaries or expose secret
+  values for inspection.
+- Do not silently rerun changed code under a different SHA and combine results.
+
+## Relevant Contracts
+
+- All evidence must reference one immutable commit SHA containing the exact
+  candidate.
+- `windows-11-arm` plus runtime `win32`/`arm64` and PE `0xAA64` are all
+  required; runner label alone is insufficient.
+- Free and Pro results are separate gates. Both must pass before packet 07.
+- Existing platforms and all Node versions remain required.
+- The Pro run is non-fork, environment-protected, least-privilege, and
+  artifact-free.
+
+## Expected Files
+
+- `docs/specs/win32-arm64-support/tasks/06_validate_native_ci.md`
+- `docs/specs/win32-arm64-support/tasks/todo.md`
+- `docs/specs/win32-arm64-support/tasks/handoff.md`
+
+No production, test, package, workflow, or public documentation file is owned
+by this packet.
+
+## Objective Acceptance
+
+- One SHA has passing normal CI, all four native Windows ARM64 quality cells,
+  public Free smoke, and protected Pro smoke.
+- Runtime and PE architecture evidence is explicit for both browser tiers.
+- Free cache transition/cleanup/concurrency assertions pass.
+- Pro no-fallback and credential non-disclosure assertions pass.
+- All existing platform jobs remain green.
+- Run URLs and conclusions are recorded without sensitive data.
+
+## Verification
+
+After the authorized GitHub run exists:
+
+```bash
+gh run list --commit <commit-sha>
+gh run view <ci-run-id>
+gh run view <pro-run-id>
+gh run view <ci-run-id> --log-failed
+gh run view <pro-run-id> --log-failed
+```
+
+Use `--log-failed` only when failures exist. Do not print all Pro logs merely to
+search for a credential. Inspect GitHub job metadata, annotations, workflow
+step scoping, and the harness's redaction assertion.
+
+Repository-state check:
+
+```bash
+git status --short
+```
+
+No repository source change is expected from this evidence-only packet.
+
+## Failure, Rollback, And Recovery
+
+- A failed, skipped, cancelled, timed-out, architecture-mismatched, or
+  secret-ineligible job is not acceptance. Leave packet 07 blocked.
+- Route deterministic code/workflow defects back to packet 03, 04, or 05 under
+  a new explicit authorization, then rerun the full gate on one new SHA.
+- Record transient runner/download failures and reruns; do not bypass signed
+  acquisition or switch runner labels.
+- If upstream `V` is withdrawn or integrity changes, invoke the coordinated R13
+  rollback of dependency, workflow, and any support claim.
+
+## Manual Gates
+
+- **MANUAL GATE — delivery mutation:** commit, push, and PR creation/update each
+  require separate explicit authorization and are outside this packet.
+- **MANUAL GATE — workflow dispatch:** manual CI or Pro dispatch requires
+  explicit authorization for the exact ref.
+- **MANUAL GATE — protected environment:** an authorized reviewer must approve
+  the Pro deployment.
+- Merge, publication, and release are not authorized.
+
+## Completion Checklist
+
+- [ ] One immutable candidate SHA recorded.
+- [ ] Existing CI jobs and platform matrix pass.
+- [ ] Four native Windows ARM64 quality cells pass.
+- [ ] Public Free native smoke passes with required evidence.
+- [ ] Protected Pro native smoke passes with required evidence.
+- [ ] Credential non-disclosure and no-artifact boundary confirmed.
+- [ ] Run URLs, IDs, refs, runners, Nodes, and conclusions recorded.
+- [ ] Handoff updated and packet 07 explicitly unblocked.
+- [ ] `todo.md` packet link checked.
+
+## Native CI Record
+
+Populate during execution:
+
+- Candidate commit SHA:
+- CI event/ref:
+- Normal CI run URL/ID:
+- Windows ARM64 quality job results:
+- Free smoke job result and architecture evidence:
+- Pro workflow run URL/ID:
+- Pro environment approval and job result:
+- Credential/artifact boundary result:
+- Reruns/transient failures:
+- Final gate result:
+
+## Handoff
+
+If every acceptance item passes, name packet 07 as the only next eligible
+packet. Otherwise record the smallest failed owning packet and keep the public
+support claim blocked.
+

--- a/docs/specs/win32-arm64-support/tasks/07_publish_compatibility_contract.md
+++ b/docs/specs/win32-arm64-support/tasks/07_publish_compatibility_contract.md
@@ -1,0 +1,181 @@
+# Packet 07 — Publish The Compatibility Contract
+
+## Outcome
+
+After both native gates pass, add Windows ARM64 to the compatibility source,
+generated tables, testing documentation, and all required locales, then finish
+the repository verification without changing the package version.
+
+## Prerequisites And Dependencies
+
+- Packet 06 is complete with passing Free and Pro evidence for one immutable
+  SHA.
+- The qualified stable upstream version remains available.
+- DeepL MCP can translate every changed human-readable fragment. The recorded
+  specification/planning localization deferral must be cleared rather than
+  hidden.
+
+## Owned Requirements
+
+- R1 Supported Platform, for the public claim
+- R8 Public Interface Stability
+- R9 Existing Compatibility
+- R12 Compatibility Documentation
+- R13 Rollback
+
+## Scope
+
+- Update the compatibility row whose version equals `package.json.version`;
+  do not add or bump a release version.
+- Set that row's `cloakbrowser` range to the packet 02 range.
+- Add native Windows ARM64 to `readmePlatforms` and `testedPlatform` while
+  preserving Linux x64/arm64, macOS x64/arm64, Windows x64, Docker
+  linux/amd64/linux/arm64, Node.js `22` and `24`–`26`, transports, and parity
+  text.
+- Run `npm run docs:compatibility` to regenerate the compact README/index table
+  and full version-compatibility table; do not hand-edit generated table
+  regions.
+- Update `docs/testing.md` to describe:
+  - the `windows-11-arm` full Node quality/package matrix;
+  - the public Free clean/warm, PE, cache-transition, diagnostics, and browser
+    smoke;
+  - the protected non-fork Pro native gate without naming or documenting any
+    credential value.
+- Surgically translate only changed human-readable fragments in all required
+  localized counterparts (`ru`, `be`, `uk`, `es`, `pt-BR`, `zh`, `ja`, `de`,
+  `fr`, and `hi`) with DeepL MCP. Preserve Markdown structure, identifiers,
+  commands, URLs, environment variables, tool/package names, and generated
+  values.
+- Resolve the existing localization deferrals for the English specification
+  and planning Markdown created by this workstream so
+  `docs:translations:check` reflects actual files. Do not create English-copy
+  placeholders.
+- Refresh only the relevant
+  `docs/data/translation-manifest.json` entries after actual translations
+  exist and their hashes match.
+
+## Non-Goals
+
+- No package version bump, changelog, release note, commit, push, PR, merge,
+  publication, or release.
+- No runtime, test, workflow, Docker, CLI, environment, MCP, transport, server,
+  or upstream tool-contract change.
+- Do not advertise Windows ARM64 for historical rows that did not contain the
+  qualified dependency/gates.
+- Do not bulk-regenerate translations with
+  `npm run docs:translations` or
+  `scripts/update-doc-translations.mjs`.
+- Do not refresh manifest hashes to conceal missing, stale, or untranslated
+  content.
+
+## Relevant Contracts
+
+- `docs/data/version-compatibility.json` is the source of truth for generated
+  compatibility tables.
+- English documentation is the source for ten required locales.
+- The public claim is native npm on Windows ARM64, not Windows Docker or x64
+  emulation.
+- Both Free and Pro gates are required; testing prose must distinguish public
+  and protected validation without exposing secret details.
+- Existing installation commands and runtime interfaces stay unchanged.
+
+## Expected Files
+
+- `docs/data/version-compatibility.json`
+- `README.md`
+- `docs/index.md` and affected `docs/index.<locale>.md` files
+- `docs/version-compatibility.md` and all
+  `docs/version-compatibility.<locale>.md` files
+- `docs/testing.md` and all `docs/testing.<locale>.md` files
+- English and localized files under
+  `docs/specs/win32-arm64-support/` needed to clear the recorded deferral
+- `docs/data/translation-manifest.json`
+- Packet/checklist/handoff state under
+  `docs/specs/win32-arm64-support/tasks/`
+
+Touch only locale files whose English source or deferred workstream counterpart
+requires an update.
+
+## Objective Acceptance
+
+- The current compatibility row and generated tables consistently claim npm on
+  Windows ARM64 and name the qualified dependency range.
+- Historical rows and every existing platform/transport claim remain intact.
+- Testing documentation truthfully describes the native quality, Free, and Pro
+  gates recorded in packet 06.
+- Every changed/deferred English document has complete surgical translations
+  in all ten locales, and manifest hashes match the actual files.
+- All documentation commands and `npm run check` pass.
+- No version, changelog, runtime interface, or unreleased publication state is
+  changed.
+
+## Verification
+
+Generate and inspect:
+
+```bash
+npm run docs:compatibility
+git diff -- docs/data/version-compatibility.json README.md docs/index.md docs/version-compatibility.md docs/testing.md
+```
+
+Documentation checks:
+
+```bash
+npm run docs:compatibility:check
+npm run docs:build
+npm run docs:seo:validate
+npm run docs:translations:check
+```
+
+Repository checks:
+
+```bash
+npm run format:check
+npm run package:verify
+npm run check
+```
+
+No translation or full-check failure may be waived when this final packet is
+completed.
+
+## Failure, Rollback, And Recovery
+
+- If either native gate loses its passing status, remove the new claim and keep
+  this packet unchecked.
+- If DeepL remains unavailable or a locale is incomplete, stop without
+  placeholders or manifest manipulation; the support implementation may remain
+  unadvertised.
+- If the upstream release is withdrawn, coordinate rollback of the dependency
+  floor, Windows ARM64 workflow changes, and public claim. Do not delete user
+  caches.
+- Regenerate tables from restored source data rather than hand-reverting
+  generated regions independently.
+
+## Manual Gates
+
+- **MANUAL GATE — translation service:** DeepL must be available for real
+  surgical translations; quota failure is not approval to defer final locale
+  acceptance.
+- Commit, push, PR, merge, publication, and release are separate
+  **MANUAL GATE** actions and are not authorized.
+
+## Completion Checklist
+
+- [ ] Packet 06 Free and Pro evidence rechecked.
+- [ ] Current compatibility source row updated without version bump.
+- [ ] Generated compatibility tables refreshed.
+- [ ] English testing contract updated.
+- [ ] All ten locales surgically updated, including prior workstream deferrals.
+- [ ] Translation manifest refreshed from actual files only.
+- [ ] Documentation checks pass.
+- [ ] Package verification and full repository check pass.
+- [ ] Handoff updated with final verification and rollback boundary.
+- [ ] `todo.md` packet link checked.
+
+## Handoff
+
+Record the changed English/localized files, packet 06 evidence referenced,
+generator output, every documentation/repository result, and any remaining
+delivery gates in `handoff.md`. Stop before commit, push, PR, merge,
+publication, or release.
+

--- a/docs/specs/win32-arm64-support/tasks/handoff.md
+++ b/docs/specs/win32-arm64-support/tasks/handoff.md
@@ -1,0 +1,119 @@
+# Native Windows ARM64 Handoff
+
+## Current State
+
+- Planning status: approved on 2026-07-25.
+- Implementation status: packet 01 was executed and is blocked; it remains
+  incomplete.
+- Completed packets: none.
+- Next eligible packet: none. Re-run
+  [01_qualify_upstream_release.md](01_qualify_upstream_release.md) only after a
+  newer stable upstream release appears.
+
+## Active Blockers
+
+- Reconfirmed on 2026-07-25, npm `latest` remains
+  `cloakbrowser@0.5.2`. Its immutable tarball maps only `win32-x64`, and signed
+  Free release `chromium-v146.0.7680.177.5` publishes no
+  `cloakbrowser-windows-arm64.zip`; it therefore fails R2.
+- The Pro workflow protection model is selected:
+  same-repository PR/manual CI with a protected `windows-arm64-pro` GitHub
+  Environment and fork PRs skipped.
+- The GitHub secret identifier is intentionally unresolved. Packet 05 is
+  blocked until a maintainer provides a non-sensitive identifier; no credential
+  value may be requested or persisted.
+- DeepL MCP reported `Quota for this billing period has been exceeded` on
+  2026-07-25. The specification and planning Markdown localizations are
+  explicitly deferred; no untranslated placeholders or false translation
+  manifest hashes may be created. Packet 07 must clear the deferral before the
+  final `docs:translations:check` can pass.
+
+## Planning Changes
+
+- `docs/specs/win32-arm64-support/decisions.yaml`
+- `docs/specs/win32-arm64-support/tasks/plan.md`
+- `docs/specs/win32-arm64-support/tasks/todo.md`
+- `docs/specs/win32-arm64-support/tasks/handoff.md`
+- `docs/specs/win32-arm64-support/tasks/01_qualify_upstream_release.md`
+- `docs/specs/win32-arm64-support/tasks/02_consume_upstream_dependency.md`
+- `docs/specs/win32-arm64-support/tasks/03_add_native_windows_smoke_harness.md`
+- `docs/specs/win32-arm64-support/tasks/04_wire_public_windows_arm_ci.md`
+- `docs/specs/win32-arm64-support/tasks/05_wire_protected_pro_ci.md`
+- `docs/specs/win32-arm64-support/tasks/06_validate_native_ci.md`
+- `docs/specs/win32-arm64-support/tasks/07_publish_compatibility_contract.md`
+
+## Planning Verification
+
+Populate after the packet bundle is validated:
+
+- YAML parse: passed.
+- Prettier: passed for the decision ledger and all planning Markdown.
+- Packet contract/requirement coverage: passed; seven packets contain every
+  required section, all packet links resolve, and R1–R13 are mapped.
+- Documentation checks: `docs:build` and `docs:seo:validate` passed.
+  `docs:translations:check` failed only for the 110 explicitly deferred
+  localized counterparts for the specification and planning bundle.
+
+Do not claim the translation check passed while the recorded DeepL blocker
+remains.
+
+## Packet 01 Execution
+
+- Result: blocked and incomplete. The candidate fails R2 before Pro, cache, or
+  negative-integrity qualification can begin.
+- Requirements evaluated: R2, with R4, R5, R7, and R13 left gated by the failed
+  upstream prerequisite.
+- Changed files:
+  - `docs/specs/win32-arm64-support/tasks/01_qualify_upstream_release.md`;
+  - `docs/specs/win32-arm64-support/tasks/todo.md`;
+  - `docs/specs/win32-arm64-support/tasks/handoff.md`.
+- `decisions.yaml` was intentionally unchanged because
+  `current.upstream-support` already records the same authoritative result.
+- No credential, private URL, authorization header, normal user cache,
+  package metadata, source, test, workflow, public contract, or compatibility
+  documentation was accessed or changed.
+- The protected Pro manual gate was not reached because the public package
+  mapping and Free archive already fail.
+- No next packet is eligible. Packet 02 must remain unchecked.
+
+Focused verification:
+
+- `npm view cloakbrowser dist-tags versions --json`: passed; `latest` is
+  `0.5.2`, with no newer published version.
+- `npm view cloakbrowser@0.5.2 ... --json`: passed; immutable integrity,
+  tarball URL, and source revision match the qualification record.
+- `npm pack cloakbrowser@0.5.2`: passed in an isolated
+  `/tmp/cloakbrowser-qualification.*` directory; tarball SHA-1 and integrity
+  match npm metadata, and the temporary directory was removed.
+- Published `dist/config.js` inspection: passed; only `win32-x64` and
+  `windows-x64` are present.
+- GitHub release query for `chromium-v146.0.7680.177.5`: passed; assets are the
+  Linux x64 archive, Windows x64 archive, `SHA256SUMS`, and
+  `SHA256SUMS.sig`, with no Windows ARM64 archive.
+- `npm run upstream:check:cloakbrowser`: passed and reported `0.5.2` as the
+  latest upstream version.
+
+Repository verification:
+
+- Prettier check for `docs/specs/win32-arm64-support`: passed.
+- `npm run docs:build`: passed.
+- `npm run docs:seo:validate`: passed.
+- `npm run docs:translations:check`: failed as expected for exactly 110
+  explicitly deferred localized counterparts in this workstream.
+- `npm run check`: failed at the same translation gate after typecheck, lint,
+  format, and compatibility checks passed. Server validation, build, tests, and
+  packaged E2E did not run because the command uses `&&`.
+- No verification command accessed a credential, private URL, authorization
+  header, or normal user cache.
+
+## Unrelated Worktree State
+
+The following pre-existing changes are outside this plan and must be preserved:
+
+- modified `AGENTS.md`;
+- modified `.agents/skills/project-pull-request/SKILL.md`;
+- modified `.agents/skills/project-release/SKILL.md`;
+- untracked repository-owned agent skill/reference files outside this
+  specification bundle.
+
+Stop if an implementation packet would overlap those files.

--- a/docs/specs/win32-arm64-support/tasks/plan.md
+++ b/docs/specs/win32-arm64-support/tasks/plan.md
@@ -1,0 +1,113 @@
+# Native Windows ARM64 Implementation Plan
+
+Status: Approved
+
+Specification: [../spec.md](../spec.md)
+
+Checklist: [todo.md](todo.md)
+
+Current handoff: [handoff.md](handoff.md)
+
+## Outcome
+
+Consume the first qualifying stable `cloakbrowser` release, prove that the
+packaged bridge resolves and launches native Windows ARM64 Free and Pro
+binaries, add native public and protected CI gates, and advertise the platform
+only after both gates pass.
+
+This plan does not authorize implementation, repository settings changes,
+credentials, commits, pushes, pull requests, workflow dispatches, publication,
+or release work.
+
+## Packet Index
+
+| Packet | Outcome | Depends on | Current gate |
+| --- | --- | --- | --- |
+| [01](01_qualify_upstream_release.md) | Qualify one stable upstream release and record reproducible evidence. | Approved specification | No qualifying stable release is currently known. |
+| [02](02_consume_upstream_dependency.md) | Raise the `cloakbrowser` dependency floor without adding bridge-local platform logic. | 01 | Packet 01 must identify the exact stable version. |
+| [03](03_add_native_windows_smoke_harness.md) | Add packaged-candidate Free and Pro native smoke coverage. | 02 | Requires native `windows-11-arm` execution for acceptance. |
+| [04](04_wire_public_windows_arm_ci.md) | Add the full Windows ARM64 quality matrix and public Free smoke. | 03 | GitHub-hosted runner execution is external. |
+| [05](05_wire_protected_pro_ci.md) | Add the protected, non-fork Pro smoke workflow. | 03 | Secret identifier is intentionally unresolved; environment setup is manual. |
+| [06](06_validate_native_ci.md) | Record successful native quality, Free, and Pro run evidence. | 04 and 05 | Push/PR/dispatch and protected-environment approval require separate authorization. |
+| [07](07_publish_compatibility_contract.md) | Publish and localize the Windows ARM64 compatibility claim. | 06 | Both native gates and DeepL translation availability must be confirmed. |
+
+## Dependency Graph
+
+```text
+01 qualify upstream
+  -> 02 dependency floor
+    -> 03 native smoke harness
+      -> 04 public quality + Free CI ─┐
+      -> 05 protected Pro CI ─────────┴─> 06 native CI evidence
+                                             -> 07 compatibility contract
+```
+
+Packets 04 and 05 may be implemented independently after packet 03. Packet 06
+requires both. Packet 07 must remain blocked until packet 06 records passing
+Free and Pro evidence.
+
+## Requirement Coverage
+
+| Requirement | Packets |
+| --- | --- |
+| R1 Supported Platform | 03, 04, 05, 06, 07 |
+| R2 Stable Upstream Dependency Gate | 01, 02 |
+| R3 Free First-Run And Cached Flow | 03, 04, 06 |
+| R4 Pro First-Run And Cached Flow | 01, 03, 05, 06 |
+| R5 Transparent Cache Transition | 01, 03, 04, 06 |
+| R6 Diagnostics | 03, 04, 05, 06 |
+| R7 Failure, Integrity, And Cleanup | 01, 03, 05, 06 |
+| R8 Public Interface Stability | 02, 03, 07 |
+| R9 Existing Compatibility | 02, 04, 06, 07 |
+| R10 Native Free CI Gate | 03, 04, 06 |
+| R11 Protected Pro CI Gate | 03, 05, 06 |
+| R12 Compatibility Documentation | 07 |
+| R13 Rollback | 01, 02, 04, 05, 06, 07 |
+
+## Contracts And Non-Goals
+
+- Native means `process.platform === "win32"`,
+  `process.arch === "arm64"`, and PE machine type `0xAA64`; x64 emulation is
+  not acceptance.
+- Both Free and Pro paths must pass before the public platform claim changes.
+- `cloakbrowser` continues to own platform mapping, downloads, signatures,
+  checksums, extraction, cache layout, and binary resolution.
+- No CLI, environment, MCP tool, tool schema, transport, server metadata,
+  logging, or forwarded Playwright MCP browser contract changes are planned.
+- No fork, prerelease dependency, vendored downloader, verification bypass,
+  native artifact build, Docker platform, version bump, publication, or
+  release is in scope.
+
+## Risks And Rollback
+
+- Upstream availability is the primary blocker. A candidate that lacks any
+  Free, Pro, integrity, diagnostics, or cache-transition property is rejected.
+- Real binary smokes download and launch third-party executables. They run only
+  on native Windows ARM64 with isolated temporary caches and a loopback page.
+- Pro validation is credentialed. The credential is step-scoped, never placed
+  in arguments or artifacts, and never recorded in this bundle.
+- GitHub-hosted ARM64 capacity and upstream downloads may be transient. A
+  failed or cancelled run is not acceptance; rerun evidence must be recorded.
+- If the accepted upstream release is withdrawn or fails either gate, revert
+  the dependency floor, Windows ARM64 workflow coverage, and public support
+  claim together. Never delete user caches as rollback.
+
+## Manual Gates
+
+- **MANUAL GATE — upstream Pro evidence:** a maintainer must make an existing
+  Pro credential available only to the protected qualification process if
+  public metadata cannot prove the Pro archive requirement.
+- **MANUAL GATE — secret identifier:** packet 05 cannot bind the workflow until
+  a maintainer supplies the non-sensitive GitHub secret identifier. Do not
+  request the credential value.
+- **MANUAL GATE — repository settings:** create/configure the
+  `windows-arm64-pro` GitHub Environment, required reviewers, allowed branches,
+  and access to the separately confirmed existing secret outside the worktree.
+- **MANUAL GATE — external GitHub mutations:** commit, push, PR creation, and
+  workflow dispatch each require separate explicit authorization.
+- **MANUAL GATE — protected run:** an authorized reviewer must approve each Pro
+  deployment.
+- **MANUAL GATE — translation service:** packet 07 cannot finish until DeepL
+  can produce the required surgical locale updates.
+- Publication, release, merge, and destructive cache cleanup are not authorized
+  by this plan.

--- a/docs/specs/win32-arm64-support/tasks/todo.md
+++ b/docs/specs/win32-arm64-support/tasks/todo.md
@@ -1,0 +1,17 @@
+# Native Windows ARM64 Task Checklist
+
+Status: Blocked — packet 01 has no qualifying stable upstream release.
+
+- [ ] [01 — Qualify the stable upstream release](01_qualify_upstream_release.md)
+- [ ] [02 — Consume the upstream dependency](02_consume_upstream_dependency.md)
+- [ ] [03 — Add the native Windows ARM64 smoke harness](03_add_native_windows_smoke_harness.md)
+- [ ] [04 — Wire public Windows ARM64 CI](04_wire_public_windows_arm_ci.md)
+- [ ] [05 — Wire protected Pro CI](05_wire_protected_pro_ci.md)
+- [ ] [06 — Validate native CI](06_validate_native_ci.md)
+- [ ] [07 — Publish the compatibility contract](07_publish_compatibility_contract.md)
+
+Complete exactly one explicitly authorized packet per implementation
+invocation. A checked packet must have its acceptance evidence and verification
+results recorded in [handoff.md](handoff.md). Do not begin the next packet,
+commit, push, open a pull request, dispatch a workflow, publish, or release
+without the corresponding separate authorization.


### PR DESCRIPTION
## Summary

- Establish the complete native Windows ARM64 support workstream for the documented npm/npx path requested in #89, covering both CloakBrowser Free and Pro.
- Add the approved requirements, decision ledger, implementation packets, acceptance gates, rollback strategy, native smoke coverage, CI design, and compatibility-documentation work needed to deliver the feature end to end.
- Record the current upstream blocker: `cloakbrowser@0.5.2` does not map `win32-arm64`, and the signed Free release publishes only a Windows x64 archive.
- Keep the bridge thin and ready to consume the first qualifying stable CloakBrowser release rather than introducing an unsigned binary, local downloader, or x64-emulation fallback.

This PR is not limited to writing a specification: it defines and tracks the overall implementation. The runtime work cannot begin yet because upstream CloakBrowser does not currently publish the required native Windows ARM64 package mapping and signed Free and Pro artifacts.

## Checklist

- [ ] I ran `npm run check` locally and it passed. It currently stops at `docs:translations:check` because 110 localized counterparts for this workstream are not yet available.
- [ ] If I changed public behavior, I updated `README.md` and relevant docs in `docs/`. Not applicable yet: this PR does not change runtime support or advertise Windows ARM64 as available.
- [ ] If I changed local bridge tools, I updated `docs/tools.md`. Not applicable: local tools are unchanged.
- [ ] If I changed bridge configuration, I updated `docs/configuration.md`. Not applicable: bridge configuration is unchanged.
- [x] Upstream Playwright MCP tool schemas, descriptions, and responses are not copied or mutated.
- [ ] I added/updated tests (unit and/or integration as appropriate). Not applicable to the current blocked planning packet; the approved workstream defines the required native Free and Pro smoke coverage.
- [ ] I added an entry to `CHANGELOG.md` under `## [Unreleased]`. Not applicable until native support is implemented and can be advertised.
- [x] I reviewed security implications and documented them below.

## Security review

This PR changes documentation and execution contracts only. It does not alter the bridge, upstream child process, filesystem access, Docker images, runtime logging, secrets or tokens, OIDC, or registry publishing.

The planned implementation preserves CloakBrowser's signed-manifest and checksum verification path, rejects x64 emulation as native support, and keeps Pro credentials restricted to protected, non-fork CI. No credential value or new secret is introduced.

## Test evidence

- `npm run docs:build` — passed.
- `npm run docs:seo:validate` — passed.
- `npm run check` — typecheck, lint, formatting, and compatibility checks passed; the command stopped at `docs:translations:check`.
- `npm run docs:translations:check` — failed because 110 required localized counterparts for the specification and task bundle are missing.
- Server validation, build, runtime tests, and packaged E2E were not reached because `npm run check` uses `&&`; no runtime source or test code changes in this PR.