### PR TITLE
build(deps): update cloakbrowser to 0.5.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,11 @@ locale is deferred. Do not use `npm run docs:translations` or
 `scripts/update-doc-translations.mjs` to bulk-regenerate localized pages unless
 the maintainer explicitly asks for that script. Instead, inspect the English
 `git diff`, identify only the changed human-readable fragments, translate those
-fragments with DeepL MCP `translate_text`, and patch the corresponding localized
-files surgically. Translate changed headings, prose, list items, and table prose;
-remove localized text when the English source removes it. Preserve Markdown
+fragments with DeepL MCP `translate_text` when it is available, and patch the
+corresponding localized files surgically. If DeepL is unavailable, returns a
+quota or service error, or cannot translate a locale, manually translate those
+same fragments with the LLM. Translate changed headings, prose, list items, and
+table prose; remove localized text when the English source removes it. Preserve Markdown
 structure, frontmatter keys, code blocks, inline code, URLs, environment
 variables, CLI flags, JSON keys, tool names, package names, image paths, and
 Material icon tokens exactly. For Markdown tables, translate only prose cells

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded CloakBrowser to 0.5.3 and added the startup-only Stable/Preview
+  release-channel control.
+- Inherited CloakBrowser's Windows font-profile argument alignment.
+
+### Fixed
+
+- Inherited CloakBrowser 0.5.3 authenticated-proxy GeoIP and per-launch proxy
+  identity corrections.
+
 ## [1.9.0] - 2026-07-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ More examples are in [Getting Started](docs/getting-started.md), with dedicated 
 
 ## Configuration
 
-Use upstream `PLAYWRIGHT_MCP_*` variables for browser, artifacts, timeouts, network, and tool capability settings. Cloak-specific bridge toggles use `CLOAK_PLAYWRIGHT_MCP_*`.
+Use upstream `PLAYWRIGHT_MCP_*` variables for browser, artifacts, timeouts, network, and tool capability settings. Cloak-specific bridge toggles use `CLOAK_PLAYWRIGHT_MCP_*`. Select a Pro Preview browser build before startup with `--release-channel preview` or `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL=preview`; the default is `stable`.
 
 The common variable table now lives in [Configuration](docs/configuration.md). That page also covers persistent profiles, validated context options, Chrome extensions, Streamable HTTP metadata, and HTTPS/auth options. See [GeoIP Proxy Matching](docs/geoip-proxy-matching.md) for regional proxy behavior, [Humanized Input Behavior](docs/humanized-input-behavior.md) for interaction realism, and [Recipes](docs/recipes/index.md) for task-focused configurations.
 

--- a/docs/configuration.be.md
+++ b/docs/configuration.be.md
@@ -36,6 +36,7 @@ tags:
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | Канал выпуску бінарнага файла CloakBrowser: `stable` або даступны толькі для Pro `preview`. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -74,6 +75,12 @@ npx -y cloakbrowser@latest logout
 кэш з файлам `license.key`, CloakBrowser вызначае ключ, а мост перадае са
 згенераванага асяроддзя браўзера толькі гэты вызначаны ключ. Іншыя
 згенераваныя запісы асяроддзя не капіруюцца.
+
+## Канал выпуску CloakBrowser
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` выбірае канал выпуску бінарнага файла CloakBrowser. Па змаўчанні выкарыстоўваецца `stable`. `preview` запытвае папярэднюю зборку браўзера Pro і даступны толькі з ліцэнзіяй Pro. Яўна зададзеная версія `CLOAKBROWSER_VERSION` мае прыярытэт. Калі Preview недаступны для платформы, CloakBrowser вяртаецца да Stable.
+
+Канал выпуску выбіраецца пры запуску працэсу моста. Ён прымяняецца да ўсіх сеансаў Streamable HTTP і не можа задавацца або пераазначацца ў метададзеных initialize. Каб змяніць яго, перазапусціце мост.
 
 ## Супастаўленне GeoIP-праксі
 

--- a/docs/configuration.de.md
+++ b/docs/configuration.de.md
@@ -36,6 +36,7 @@ Die generierte [CLI-Referenz](generated/cli.md) ist die maßgebliche Liste der B
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | CloakBrowser-Binär-Release-Kanal: `stable` oder das nur für Pro verfügbare `preview`. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -75,6 +76,12 @@ Upstream-/Browser-Kindprozess weiter, ohne sie zu protokollieren. Wenn
 verweist, löst CloakBrowser den Schlüssel auf und die Bridge leitet aus der
 generierten Browserumgebung nur diesen aufgelösten Schlüssel weiter. Andere
 generierte Umgebungseinträge werden nicht kopiert.
+
+## CloakBrowser-Release-Kanal
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` wählt den Release-Kanal des CloakBrowser-Binärprogramms. Die Vorgabe ist `stable`. `preview` fordert einen Pro-Preview-Browser-Build an und ist nur mit einer Pro-Lizenz verfügbar. Eine explizite Festlegung von `CLOAKBROWSER_VERSION` hat Vorrang. Ist Preview für die Plattform nicht verfügbar, fällt CloakBrowser auf Stable zurück.
+
+Der Release-Kanal wird beim Start des Bridge-Prozesses gewählt. Er gilt für alle Streamable-HTTP-Sitzungen und kann nicht in initialize-Metadaten gesetzt oder überschrieben werden. Starten Sie die Bridge neu, um ihn zu ändern.
 
 ## GeoIP-Proxy-Zuordnung
 

--- a/docs/configuration.es.md
+++ b/docs/configuration.es.md
@@ -36,6 +36,7 @@ La [Referencia de la CLI](generated/cli.md) generada es la lista oficial de los 
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | Canal de lanzamiento del binario de CloakBrowser: `stable` o `preview`, solo para Pro. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -74,6 +75,12 @@ navegador sin registrarla. Si `CLOAKBROWSER_CACHE_DIR` apunta a una caché
 personalizada que contiene `license.key`, CloakBrowser resuelve la clave y el
 puente reenvía únicamente esa clave resuelta desde el entorno generado del
 navegador. No se copian otras entradas de entorno generadas.
+
+## Canal de lanzamiento de CloakBrowser
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` selecciona el canal de lanzamiento del binario de CloakBrowser. El valor predeterminado es `stable`. `preview` solicita una compilación previa de navegador Pro y solo está disponible con una licencia Pro. Una versión fijada explícitamente mediante `CLOAKBROWSER_VERSION` tiene prioridad. Si Preview no está disponible para la plataforma, CloakBrowser vuelve a Stable.
+
+El canal de lanzamiento se selecciona cuando se inicia el proceso del puente. Se aplica a todas las sesiones de Streamable HTTP y no se puede establecer ni reemplazar en los metadatos de initialize. Reinicie el puente para cambiarlo.
 
 ## Coincidencia de proxy GeoIP
 

--- a/docs/configuration.fr.md
+++ b/docs/configuration.fr.md
@@ -36,6 +36,7 @@ La [Référence CLI](generated/cli.md) générée constitue la liste de référe
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | Canal de publication du binaire CloakBrowser : `stable` ou `preview`, réservé à Pro. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -75,6 +76,12 @@ pointe vers un cache personnalisé contenant `license.key`, CloakBrowser résout
 la clé et le pont ne transmet que cette clé résolue depuis l'environnement
 généré du navigateur. Les autres entrées d'environnement générées ne sont pas
 copiées.
+
+## Canal de publication de CloakBrowser
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` sélectionne le canal de publication du binaire CloakBrowser. La valeur par défaut est `stable`. `preview` demande une version Preview du navigateur Pro et est disponible uniquement avec une licence Pro. Un verrouillage explicite de `CLOAKBROWSER_VERSION` est prioritaire. Si Preview n'est pas disponible pour la plateforme, CloakBrowser revient à Stable.
+
+Le canal de publication est choisi au démarrage du processus de pont. Il s'applique à toutes les sessions Streamable HTTP et ne peut pas être défini ni remplacé dans les métadonnées initialize. Redémarrez le pont pour le modifier.
 
 ## Correspondance via le proxy GeoIP
 

--- a/docs/configuration.hi.md
+++ b/docs/configuration.hi.md
@@ -36,6 +36,7 @@ Playwright MCP व्यवहार के लिए अपस्ट्री�
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | CloakBrowser बाइनरी रिलीज़ चैनल: `stable` या केवल Pro के लिए `preview`। |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -73,6 +74,12 @@ npx -y cloakbrowser@latest logout
 CloakBrowser कुंजी को रिज़ॉल्व करता है और ब्रिज जेनरेट किए गए ब्राउज़र परिवेश
 से केवल उसी रिज़ॉल्व की गई कुंजी को भेजता है। अन्य जेनरेट की गई परिवेश
 प्रविष्टियाँ कॉपी नहीं की जातीं।
+
+## CloakBrowser रिलीज़ चैनल
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` CloakBrowser बाइनरी रिलीज़ चैनल चुनता है। इसका डिफ़ॉल्ट `stable` है। `preview` Pro ब्राउज़र की Preview बिल्ड का अनुरोध करता है और केवल Pro लाइसेंस के साथ उपलब्ध है। स्पष्ट रूप से पिन किया गया `CLOAKBROWSER_VERSION` प्राथमिकता लेता है। यदि प्लेटफ़ॉर्म के लिए Preview उपलब्ध नहीं है, तो CloakBrowser Stable पर वापस आ जाता है।
+
+रिलीज़ चैनल ब्रिज प्रक्रिया शुरू होने पर चुना जाता है। यह सभी Streamable HTTP सत्रों पर लागू होता है और initialize मेटाडेटा में इसे सेट या ओवरराइड नहीं किया जा सकता। इसे बदलने के लिए ब्रिज को पुनः आरंभ करें।
 
 ## GeoIP प्रॉक्सी मिलान
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -36,6 +36,7 @@ Playwright MCP の動作には、アップストリームの `PLAYWRIGHT_MCP_*` 
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | CloakBrowser バイナリのリリースチャネル: `stable` または Pro 限定の `preview`。 |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -72,6 +73,12 @@ npx -y cloakbrowser@latest logout
 `CLOAKBROWSER_CACHE_DIR` が `license.key` を含むカスタムキャッシュを指している場合、
 CloakBrowser がキーを解決し、ブリッジは生成されたブラウザ環境からその解決済みキー
 だけを転送します。生成されたその他の環境エントリはコピーされません。
+
+## CloakBrowser リリースチャネル
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` は CloakBrowser バイナリのリリースチャネルを選択します。既定値は `stable` です。`preview` は Pro 向けのプレビュー版ブラウザビルドを要求し、Pro ライセンスでのみ利用できます。明示的に固定した `CLOAKBROWSER_VERSION` が優先されます。プラットフォームで Preview を利用できない場合、CloakBrowser は Stable にフォールバックします。
+
+リリースチャネルはブリッジプロセスの起動時に選択されます。すべての Streamable HTTP セッションに適用され、initialize メタデータで設定または上書きすることはできません。変更するにはブリッジを再起動してください。
 
 ## GeoIPプロキシのマッチング
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ For task-focused examples, see the [Recipes](recipes/index.md) section.
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | CloakBrowser binary release channel: `stable` or Pro-only `preview`. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -74,6 +75,18 @@ logging it. When `CLOAKBROWSER_CACHE_DIR` points to a custom cache containing
 `license.key`, CloakBrowser resolves the key and the bridge forwards only that
 resolved key from the generated browser environment. Other generated
 environment entries are not copied.
+
+## CloakBrowser Release Channel
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` selects the CloakBrowser binary release
+channel. It defaults to `stable`. `preview` requests a Pro Preview browser
+build and is available only with a Pro license. An explicit
+`CLOAKBROWSER_VERSION` pin takes precedence. If Preview is unavailable for the
+platform, CloakBrowser falls back to Stable.
+
+The release channel is selected when the bridge process starts. It applies to
+all Streamable HTTP sessions and cannot be set or overridden in initialize
+metadata. Restart the bridge to change it.
 
 ## GeoIP Proxy Matching
 

--- a/docs/configuration.pt-BR.md
+++ b/docs/configuration.pt-BR.md
@@ -36,6 +36,7 @@ A [Referência da CLI](generated/cli.md) gerada é a lista oficial dos sinalizad
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | Canal de lançamento do binário do CloakBrowser: `stable` ou `preview`, disponível apenas no Pro. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -73,6 +74,12 @@ sem registrá-la em logs. Quando `CLOAKBROWSER_CACHE_DIR` aponta para um cache
 personalizado que contém `license.key`, o CloakBrowser resolve a chave e a
 ponte encaminha apenas essa chave resolvida a partir do ambiente gerado do
 navegador. Outras entradas de ambiente geradas não são copiadas.
+
+## Canal de lançamento do CloakBrowser
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` seleciona o canal de lançamento do binário do CloakBrowser. O padrão é `stable`. `preview` solicita uma versão de prévia do navegador Pro e está disponível apenas com uma licença Pro. Uma versão fixada explicitamente em `CLOAKBROWSER_VERSION` tem precedência. Se o Preview não estiver disponível para a plataforma, o CloakBrowser volta para Stable.
+
+O canal de lançamento é selecionado quando o processo da ponte é iniciado. Ele se aplica a todas as sessões de Streamable HTTP e não pode ser definido nem substituído nos metadados de initialize. Reinicie a ponte para alterá-lo.
 
 ## Correspondência de proxy GeoIP
 

--- a/docs/configuration.ru.md
+++ b/docs/configuration.ru.md
@@ -36,6 +36,7 @@ tags:
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | Канал выпуска двоичного файла CloakBrowser: `stable` или доступный только для Pro `preview`. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -74,6 +75,12 @@ npx -y cloakbrowser@latest logout
 пользовательский кэш с файлом `license.key`, CloakBrowser разрешает ключ, а мост
 передает из сгенерированного окружения браузера только этот разрешенный ключ.
 Другие сгенерированные записи окружения не копируются.
+
+## Канал выпуска CloakBrowser
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` выбирает канал выпуска двоичного файла CloakBrowser. По умолчанию используется `stable`. `preview` запрашивает предварительную Pro-сборку браузера и доступен только с лицензией Pro. Явное закрепление `CLOAKBROWSER_VERSION` имеет приоритет. Если Preview недоступен для платформы, CloakBrowser переключается на Stable.
+
+Канал выпуска выбирается при запуске процесса моста. Он применяется ко всем сеансам Streamable HTTP и не может задаваться или переопределяться в метаданных initialize. Чтобы изменить его, перезапустите мост.
 
 ## Сопоставление прокси-серверов по GeoIP
 

--- a/docs/configuration.uk.md
+++ b/docs/configuration.uk.md
@@ -36,6 +36,7 @@ tags:
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | Канал випуску двійкового файла CloakBrowser: `stable` або доступний лише для Pro `preview`. |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -74,6 +75,12 @@ npx -y cloakbrowser@latest logout
 кеш із файлом `license.key`, CloakBrowser визначає ключ, а міст передає зі
 згенерованого середовища браузера лише цей визначений ключ. Інші згенеровані
 записи середовища не копіюються.
+
+## Канал випуску CloakBrowser
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` вибирає канал випуску двійкового файла CloakBrowser. Типове значення — `stable`. `preview` запитує попередню Pro-збірку браузера та доступний лише з ліцензією Pro. Явно задана версія `CLOAKBROWSER_VERSION` має пріоритет. Якщо Preview недоступний для платформи, CloakBrowser повертається до Stable.
+
+Канал випуску вибирається під час запуску процесу моста. Він застосовується до всіх сеансів Streamable HTTP і не може задаватися чи перевизначатися в метаданих initialize. Щоб змінити його, перезапустіть міст.
 
 ## Збіг проксі-серверів за GeoIP
 

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -36,6 +36,7 @@ tags:
 | `CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH` | `false` | Resolves `PLAYWRIGHT_MCP_PROXY_SERVER` GeoIP and matches CloakBrowser timezone and locale fingerprint flags to that proxy location. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMANIZE` | `false` | Enables CloakBrowser human-like mouse, keyboard, and scroll behavior. |
 | `CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET` | `default` | CloakBrowser human behavior preset: `default` or `careful`. Used only when humanize is enabled. |
+| `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` | `stable` | CloakBrowser 二进制文件发布通道：`stable` 或仅限 Pro 的 `preview`。 |
 | `PLAYWRIGHT_MCP_BROWSER_ENGINE` | `cloak` | `cloak` uses the CloakBrowser binary. `playwright` skips Cloak-specific executable replacement. |
 | `PLAYWRIGHT_MCP_HEADLESS` | `true` | Runs Chromium in headless mode. |
 | `PLAYWRIGHT_MCP_OUTPUT_DIR` | `.playwright-mcp` | Artifact directory for npm. Docker sets `/data`. |
@@ -69,6 +70,12 @@ npx -y cloakbrowser@latest logout
 上游/浏览器子进程，但不会记录它。当 `CLOAKBROWSER_CACHE_DIR` 指向包含
 `license.key` 的自定义缓存时，CloakBrowser 会解析密钥，而桥接器只会从生成的浏览器
 环境中转发该解析后的密钥。其他生成的环境条目不会被复制。
+
+## CloakBrowser 发布通道
+
+`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL` 选择 CloakBrowser 二进制文件的发布通道。默认值为 `stable`。`preview` 请求 Pro 浏览器预览构建，且仅适用于 Pro 许可证。显式固定的 `CLOAKBROWSER_VERSION` 优先。如果平台没有可用的 Preview，CloakBrowser 会回退到 Stable。
+
+发布通道在桥接进程启动时选定。它适用于所有 Streamable HTTP 会话，且不能在 initialize 元数据中设置或覆盖。请重启桥接进程以更改它。
 
 ## GeoIP 代理匹配
 

--- a/docs/data/translation-manifest.json
+++ b/docs/data/translation-manifest.json
@@ -120,77 +120,77 @@
       }
     },
     "configuration.md": {
-      "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
+      "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
       "translations": {
         "ru": {
           "path": "configuration.ru.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "04b9c94c04f59f1aedb72178d32c94d3ca984537c0024821fc6829096fa92cb8",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "6d7d516d46ebf93ebdc76d204ec133e608948b9d0c4349c862e81082f0c28fd3",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "be": {
           "path": "configuration.be.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "a38794a7b5f231c2fb5550a9adfd78dc4932f1399126319fae4743f93d1e9569",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "1692ed896faf8460135a0545985882ae75acbf9c8f164825e91cbef26a3e6a20",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "uk": {
           "path": "configuration.uk.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "d9c2a319fc5ee6dca55c49bae4603012e38233059486ef909bd35e14df00433f",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "c88895840542a8baf6075c90e3cd1a8eda30025c25baa3da2a313503ca21547c",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "es": {
           "path": "configuration.es.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "191473a08d95898c54d8cdb6b8c8cd1d41b8046cfc7132ced26a558cc38d818d",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "6a8b40a0eb5f8a483ed481e32a3e66e4891574f68b22cc0ca2d4625ef2081f91",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "pt-BR": {
           "path": "configuration.pt-BR.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "dedb0a88da719c0d756485fb4d96a15658bb05585007f3ce97b7c0de25747e86",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "62cfcb5ba30432a39c9ed4649540f438ae0866bb2e8e95d721175719c7e48d68",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "zh": {
           "path": "configuration.zh.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "ef3827310ddf6598c2ffbd16c64e47e351dc4501303cd9b3f1b3c210ec44cf35",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "68cbc265c1b87e0422f4cfee8d208c74da9d63f5a28ecf8c123e55acea99220d",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "ja": {
           "path": "configuration.ja.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "aa3150765b9324d415d8ac398da170cee9e2c4921639a46f2d7f78dd69b8519a",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "de1ba46a10551a2ad87ec4d88356b1e15d9020e985fe8bb4a642a0753ce235c3",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "de": {
           "path": "configuration.de.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "0b46e92c3acf726698b92f6679a2bd7e3c776c70d23ecd5888afdc1cace2175f",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "dd076447f2ba0d676496aeb2ff0acd29376ed7b38df02e70e0ff797e17e9c8c8",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "fr": {
           "path": "configuration.fr.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "56f6d72c0fbbc4d7fbf93a3d979adb3af486b49f53af90b02f22c9f0e6a7e2de",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "c01d7fa8d2ac919b8657dca9d01361d916d66a56df105e79df115f6f1271f73e",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         },
         "hi": {
           "path": "configuration.hi.md",
-          "sourceHash": "79f85a6433987814b7be0e0733360c54e3cf032e4aee2c565543cb5db2c4418d",
-          "translationHash": "06525c893927f4fa9e939a5bbe983ad19149ae5b30d81b785448c47d9e33dcdc",
-          "translator": "manual targeted translation (DeepL quota fallback)",
-          "updatedAt": "2026-07-23T11:43:37.000Z"
+          "sourceHash": "4507b79bd773cbf441973d1d9d81766d0b6f8a6b081bd4f27f53863166faacfc",
+          "translationHash": "9c7b8ac22173de2702498438a63813b3cf37adc706fa4d575c4c3598cb2c2c81",
+          "translator": "manual targeted translation (LLM fallback after DeepL quota exceeded)",
+          "updatedAt": "2026-07-30T11:00:48+03:00"
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/mcp": "^0.0.78",
-        "cloakbrowser": "^0.5.1",
+        "cloakbrowser": "^0.5.3",
         "commander": "^15.0.0",
         "mmdb-lib": "^3.0.2",
         "pino": "^10.3.1",
@@ -2763,9 +2763,9 @@
       }
     },
     "node_modules/cloakbrowser": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.5.1.tgz",
-      "integrity": "sha512-GdRvMrNVWbOGczo8FMaS3rMGws7kNrSiJHQYIjczzAGG8OiHhANx0kBKEKL3roPCITulzqArxqeLfvKO+oYgDQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.5.3.tgz",
+      "integrity": "sha512-awxjoA3y+id0H9m9278GXftCkgcRcJSWu9D1Oc5E76L063GyMkNbTii8ZCrEQ4zA7b3H3zjRWF+HCtwpHwrsrw==",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/mcp": "^0.0.78",
-    "cloakbrowser": "^0.5.1",
+    "cloakbrowser": "^0.5.3",
     "commander": "^15.0.0",
     "mmdb-lib": "^3.0.2",
     "pino": "^10.3.1",

--- a/scripts/lib/npm-package.mjs
+++ b/scripts/lib/npm-package.mjs
@@ -40,3 +40,38 @@ export function assertPackageFileList(files) {
 export function formatBytes(bytes) {
   return `${Math.round(bytes / 1024)} KiB`;
 }
+
+export function parseNpmPackOutput(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('npm pack --json returned invalid JSON');
+  }
+
+  const entries = Array.isArray(parsed) ? parsed : isRecord(parsed) ? Object.values(parsed) : [];
+
+  if (entries.length !== 1 || !isNpmPackResult(entries[0])) {
+    throw new Error('npm pack --json must describe exactly one package');
+  }
+
+  return entries[0];
+}
+
+function isNpmPackResult(value) {
+  return (
+    isRecord(value) &&
+    typeof value.entryCount === 'number' &&
+    Array.isArray(value.files) &&
+    value.files.every((file) => isRecord(file) && typeof file.path === 'string') &&
+    typeof value.filename === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.size === 'number' &&
+    typeof value.unpackedSize === 'number' &&
+    typeof value.version === 'string'
+  );
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -6,7 +6,7 @@ import process from 'node:process';
 import { runCommand } from '#scripts/lib/command';
 import { readJson } from '#scripts/lib/files';
 import { appendGithubOutput } from '#scripts/lib/github-output';
-import { assertPackageFileList, formatBytes } from '#scripts/lib/npm-package';
+import { assertPackageFileList, formatBytes, parseNpmPackOutput } from '#scripts/lib/npm-package';
 
 const root = process.cwd();
 const packageJsonPath = path.join(root, 'package.json');
@@ -35,11 +35,7 @@ function packProject() {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'inherit'],
   });
-  const results = JSON.parse(raw);
-  if (!Array.isArray(results) || results.length !== 1) {
-    throw new Error(`expected npm pack to return one package, got ${raw}`);
-  }
-  return results[0];
+  return parseNpmPackOutput(raw);
 }
 
 function verifyInstall(packageFile) {

--- a/src/bridge/config.ts
+++ b/src/bridge/config.ts
@@ -31,6 +31,8 @@ import { consoleFallbackInitScript, consoleFallbackPreloadScript } from '#src/ru
 export type BrowserEngine = 'cloak' | 'playwright';
 export const humanPresets = ['default', 'careful'] as const;
 export type HumanPreset = (typeof humanPresets)[number];
+export const releaseChannels = ['stable', 'preview'] as const;
+export type ReleaseChannel = (typeof releaseChannels)[number];
 type CloakBuildLaunchOptions = typeof buildLaunchOptions;
 type CloakLaunchOptions = NonNullable<Parameters<CloakBuildLaunchOptions>[0]>;
 type CloakLaunchOptionsWithExtensions = CloakLaunchOptions & { extensionPaths?: string[] };
@@ -105,6 +107,7 @@ export interface PrepareBridgeRuntimeOptions {
   humanize?: boolean;
   humanPreset?: HumanPreset;
   proxy?: BridgeRuntimeProxy;
+  releaseChannel?: ReleaseChannel;
   userDataDir?: string;
 }
 
@@ -345,6 +348,7 @@ async function configureCloakRuntime(
     contextOptions: runtime.browserConfig.contextOptions,
     buildCloakLaunchOptions: options.buildCloakLaunchOptions ?? buildLaunchOptions,
     geoip: shouldMatchProxyGeoip(runtime.env, options.geoipProxyMatch),
+    releaseChannel: resolveReleaseChannel(runtime.env, options.releaseChannel),
   });
   runtime.launchOptions.args = cloakLaunchOptions.args;
   if (cloakLaunchOptions.proxy === undefined) delete runtime.launchOptions.proxy;
@@ -428,6 +432,7 @@ interface ResolveCloakLaunchOptionsOptions {
   contextOptions?: BridgeContextOptions;
   buildCloakLaunchOptions: CloakBuildLaunchOptions;
   geoip: boolean;
+  releaseChannel: ReleaseChannel;
 }
 
 async function resolveCloakLaunchOptions(
@@ -458,6 +463,7 @@ function createCloakLaunchOptions(
     args: options.args,
     ...(proxy === undefined ? {} : { proxy }),
     ...(geoip ? { geoip: true } : {}),
+    releaseChannel: options.releaseChannel,
     ...(options.extensionPaths.length === 0 ? {} : { extensionPaths: options.extensionPaths }),
     ...(options.contextOptions?.viewport === undefined ? {} : { viewport: options.contextOptions.viewport }),
     launchOptions:
@@ -836,6 +842,19 @@ export function parseHumanPreset(value: string): HumanPreset {
 
 function isHumanPreset(value: string): value is HumanPreset {
   return humanPresets.includes(value as HumanPreset);
+}
+
+function parseReleaseChannel(value: string): ReleaseChannel {
+  if (isReleaseChannel(value)) return value;
+  throw new Error(`CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL must be "stable" or "preview", got "${value}"`);
+}
+
+function resolveReleaseChannel(env: EnvReader, explicit: ReleaseChannel | undefined): ReleaseChannel {
+  return explicit ?? parseReleaseChannel(envString(env, 'CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL', 'stable'));
+}
+
+function isReleaseChannel(value: string): value is ReleaseChannel {
+  return releaseChannels.includes(value as ReleaseChannel);
 }
 
 function resolveHumanizeInitPagePath(): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ async function main(): Promise<void> {
   });
   command.action(async () => {
     const options = readCliOptions(command);
+    const { releaseChannel, ...runtimeOptions } = options.bridge;
     const serverInfo = {
       name: PROJECT_METADATA.mcpName,
       title: PROJECT_METADATA.title,
@@ -41,9 +42,10 @@ async function main(): Promise<void> {
         ? await startStreamableHttpCliBridge({
             ...options.http,
             serverInfo,
-            runtimeOptions: options.bridge,
+            releaseChannel,
+            runtimeOptions,
           })
-        : await startStdioBridge(serverInfo, options.bridge);
+        : await startStdioBridge(serverInfo, { ...runtimeOptions, releaseChannel });
 
     for (const signal of ['SIGINT', 'SIGTERM'] as const) {
       process.once(signal, () => {

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,5 +1,5 @@
 import { Command, InvalidArgumentError, Option } from 'commander';
-import { type HumanPreset, humanPresets } from '#src/bridge/config';
+import { type HumanPreset, humanPresets, type ReleaseChannel, releaseChannels } from '#src/bridge/config';
 import {
   BRIDGE_TRANSPORT_STDIO,
   type BridgeTransportMode,
@@ -24,6 +24,7 @@ interface CommanderCliOptions {
   geoipProxyMatch: boolean;
   humanize: boolean;
   humanPreset: HumanPreset;
+  releaseChannel: ReleaseChannel;
   httpProtocol: HttpProtocol;
   httpHost: string;
   httpPort: number;
@@ -93,6 +94,15 @@ export const cliOptionDefinitions: readonly CliOptionDefinition[] = [
     group: 'Bridge',
     defaultValue: defaultBridgeOptions.humanPreset,
     choices: humanPresets,
+  },
+  {
+    name: 'releaseChannel',
+    flags: '--release-channel <channel>',
+    description: 'CloakBrowser binary release channel.',
+    env: 'CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL',
+    group: 'Bridge',
+    defaultValue: defaultBridgeOptions.releaseChannel,
+    choices: releaseChannels,
   },
   {
     name: 'httpProtocol',
@@ -304,6 +314,7 @@ function toCliOptions(options: CommanderCliOptions, command: Command): CliOption
       ),
       humanize: normalizeBoolean(options.humanize, readRawBooleanEnv(command, 'humanize')),
       humanPreset: options.humanPreset,
+      releaseChannel: options.releaseChannel,
     },
     http: {
       protocol: options.httpProtocol,

--- a/src/http/options.ts
+++ b/src/http/options.ts
@@ -1,4 +1,4 @@
-import type { HumanPreset } from '#src/bridge/config';
+import type { HumanPreset, ReleaseChannel } from '#src/bridge/config';
 
 export const BRIDGE_TRANSPORT_STDIO = 'stdio' as const;
 export const BRIDGE_TRANSPORT_STREAMABLE_HTTP = 'streamable-http' as const;
@@ -49,6 +49,7 @@ export interface BridgeOptions {
   geoipProxyMatch: boolean;
   humanize: boolean;
   humanPreset: HumanPreset;
+  releaseChannel: ReleaseChannel;
 }
 
 export interface CliOptions {
@@ -61,6 +62,7 @@ export const defaultBridgeOptions: BridgeOptions = {
   geoipProxyMatch: false,
   humanize: false,
   humanPreset: 'default',
+  releaseChannel: 'stable',
 };
 
 export const defaultStreamableHttpOptions: StreamableHttpOptions = {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -41,11 +41,16 @@ import {
   requestPathName,
 } from '#src/http/requests';
 import { endResponse, writeJsonResponse, writeJsonRpcError } from '#src/http/responses';
-import { BridgeRuntimeConfigurationError, type PrepareBridgeRuntimeOptions } from '#src/bridge/config';
+import {
+  BridgeRuntimeConfigurationError,
+  type PrepareBridgeRuntimeOptions,
+  type ReleaseChannel,
+} from '#src/bridge/config';
 
 const allowedMethods = 'GET, POST, DELETE';
 
 export interface StartStreamableHttpBridgeOptions extends StreamableHttpOptions {
+  releaseChannel?: ReleaseChannel;
   serverInfo?: Partial<Implementation>;
   runtimeOptions?: Pick<
     PrepareBridgeRuntimeOptions,
@@ -364,6 +369,7 @@ class StreamableHttpBridgeController {
       headless: preferSessionOption(sessionRuntimeOptions.headless, defaults?.headless),
       humanize: preferSessionOption(sessionRuntimeOptions.humanize, defaults?.humanize),
       humanPreset: preferSessionOption(sessionRuntimeOptions.humanPreset, defaults?.humanPreset),
+      releaseChannel: this.#options.releaseChannel,
       userDataDir: preferSessionOption(sessionRuntimeOptions.userDataDir, defaults?.userDataDir),
       contextOptions: mergeContextOptions(defaults?.contextOptions, sessionRuntimeOptions.contextOptions),
       extensionPaths: preferSessionOption(sessionRuntimeOptions.extensionPaths, defaults?.extensionPaths),

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -158,6 +158,46 @@ describe('bridge config generation', () => {
     runtime.dispose();
   });
 
+  it('defaults CloakBrowser to the Stable release channel and forwards Preview', async () => {
+    const root = createTempRoot();
+    const stableRuntime = await prepareBridgeRuntime({
+      tempRoot: root,
+      ensureCloakBinary: async () => fakeCloakBinaryPath,
+      buildCloakLaunchOptions: async (options) => {
+        expect(options?.releaseChannel).toBe('stable');
+        return {
+          executablePath: fakeCloakBinaryPath,
+          headless: true,
+          args: options?.args ?? [],
+        };
+      },
+      env: {
+        PLAYWRIGHT_MCP_OUTPUT_DIR: path.join(root, 'stable-artifacts'),
+        CLOAK_PLAYWRIGHT_MCP_CONSOLE_FALLBACK: 'false',
+      },
+    });
+    stableRuntime.dispose();
+
+    const previewRuntime = await prepareBridgeRuntime({
+      tempRoot: root,
+      releaseChannel: 'preview',
+      ensureCloakBinary: async () => fakeCloakBinaryPath,
+      buildCloakLaunchOptions: async (options) => {
+        expect(options?.releaseChannel).toBe('preview');
+        return {
+          executablePath: fakeCloakBinaryPath,
+          headless: true,
+          args: options?.args ?? [],
+        };
+      },
+      env: {
+        PLAYWRIGHT_MCP_OUTPUT_DIR: path.join(root, 'preview-artifacts'),
+        CLOAK_PLAYWRIGHT_MCP_CONSOLE_FALLBACK: 'false',
+      },
+    });
+    previewRuntime.dispose();
+  });
+
   it('adds the console fallback preload when enabled', async () => {
     const root = createTempRoot();
     const runtime = await prepareBridgeRuntime({

--- a/tests/unit/http-options.test.ts
+++ b/tests/unit/http-options.test.ts
@@ -28,6 +28,7 @@ describe('Commander CLI options', () => {
       expect(options.bridge.geoipProxyMatch).toBe(false);
       expect(options.bridge.humanize).toBe(false);
       expect(options.bridge.humanPreset).toBe('default');
+      expect(options.bridge.releaseChannel).toBe('stable');
       expect(options.http).toMatchObject({
         protocol: HTTP_PROTOCOL_HTTP,
         host: defaultStreamableHttpOptions.host,
@@ -78,6 +79,13 @@ describe('Commander CLI options', () => {
     withCliEnv({ CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET: 'careful' }, () => {
       expect(parseCliOptions([]).bridge.humanPreset).toBe('careful');
       expect(parseCliOptions(['--human-preset', 'default']).bridge.humanPreset).toBe('default');
+    });
+  });
+
+  it('reads the release channel from env and CLI flags', () => {
+    withCliEnv({ CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL: 'preview' }, () => {
+      expect(parseCliOptions([]).bridge.releaseChannel).toBe('preview');
+      expect(parseCliOptions(['--release-channel', 'stable']).bridge.releaseChannel).toBe('stable');
     });
   });
 
@@ -136,6 +144,14 @@ describe('Commander CLI options', () => {
     });
     withCliEnv({ CLOAK_PLAYWRIGHT_MCP_HUMAN_PRESET: 'fast' }, () => {
       expect(() => parseCliOptions([])).toThrow('Allowed choices are default, careful');
+    });
+    withCliEnv({ CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL: 'canary' }, () => {
+      expect(() => parseCliOptions([])).toThrow('Allowed choices are stable, preview');
+    });
+    withCliEnv({}, () => {
+      expect(() => parseCliOptions(['--release-channel', 'canary'])).toThrow(
+        'Allowed choices are stable, preview',
+      );
     });
   });
 
@@ -269,6 +285,7 @@ describe('Commander CLI options', () => {
     expect(help).toContain('Playwright MCP bridge backed by CloakBrowser');
     expect(help).toContain('--transport <mode>');
     expect(help).toContain('--geoip-proxy-match');
+    expect(help).toContain('--release-channel <channel>');
     expect(help).toContain('doctor');
     expect(help).toContain('--http-protocol <protocol>');
     expect(help).toContain('--https-cert <path>');
@@ -277,6 +294,7 @@ describe('Commander CLI options', () => {
     expect(reference).toContain('# CLI Reference');
     expect(reference).toContain('### `doctor`');
     expect(reference).toContain('CLOAK_PLAYWRIGHT_MCP_GEOIP_PROXY_MATCH');
+    expect(reference).toContain('CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL');
     expect(reference).toContain('--json');
     expect(reference).toContain('| `--http-auth-token <token>` |');
     expect(reference).toContain('`streamable-http`');

--- a/tests/unit/http-requests.test.ts
+++ b/tests/unit/http-requests.test.ts
@@ -52,6 +52,7 @@ describe('HTTP request helpers', () => {
           headless: false,
           humanize: true,
           humanPreset: 'careful',
+          releaseChannel: 'preview',
           userDataDir: ' /tmp/profile ',
           contextOptions: {
             viewport: { width: 1280, height: 720 },
@@ -78,6 +79,10 @@ describe('HTTP request helpers', () => {
       },
       extensionPaths: ['/tmp/ext-one', '/tmp/ext-two'],
     });
+
+    expect(
+      readBridgeRuntimeOptionsFromInitialize(createInitializeRequest({ releaseChannel: 'preview' })),
+    ).toEqual({});
 
     expect(readBridgeRuntimeOptionsFromInitialize(createInitializeRequest())).toEqual({});
     expect(readBridgeRuntimeOptionsFromInitialize({ method: 'tools/list' })).toEqual({});

--- a/tests/unit/script-core-libs.test.ts
+++ b/tests/unit/script-core-libs.test.ts
@@ -34,7 +34,18 @@ interface IndexNowModule {
 interface NpmPackageModule {
   assertPackageFileList(files: string[]): void;
   formatBytes(bytes: number): string;
+  parseNpmPackOutput(raw: string): NpmPackResult;
   requiredPackageFiles: string[];
+}
+
+interface NpmPackResult {
+  entryCount: number;
+  filename: string;
+  files: Array<{ path: string }>;
+  name: string;
+  size: number;
+  unpackedSize: number;
+  version: string;
 }
 
 interface ParityModule {
@@ -216,6 +227,42 @@ describe('npm package helpers', () => {
       npmPackage.assertPackageFileList([...npmPackage.requiredPackageFiles, 'src/private.ts']),
     ).toThrow('npm package contains non-runtime files');
     expect(npmPackage.formatBytes(2048)).toBe('2 KiB');
+  });
+
+  it('parses npm pack JSON from supported npm formats', () => {
+    const packed: NpmPackResult = {
+      entryCount: 1,
+      filename: 'cloakbrowser-mcp-1.9.0.tgz',
+      files: [{ path: 'package.json' }],
+      name: 'cloakbrowser-mcp',
+      size: 1024,
+      unpackedSize: 2048,
+      version: '1.9.0',
+    };
+
+    expect(npmPackage.parseNpmPackOutput(JSON.stringify([packed]))).toEqual(packed);
+    expect(npmPackage.parseNpmPackOutput(JSON.stringify({ 'cloakbrowser-mcp': packed }))).toEqual(packed);
+  });
+
+  it('rejects invalid npm pack JSON output', () => {
+    const packed: NpmPackResult = {
+      entryCount: 1,
+      filename: 'cloakbrowser-mcp-1.9.0.tgz',
+      files: [{ path: 'package.json' }],
+      name: 'cloakbrowser-mcp',
+      size: 1024,
+      unpackedSize: 2048,
+      version: '1.9.0',
+    };
+
+    expect(() => npmPackage.parseNpmPackOutput('not json')).toThrow('invalid JSON');
+    expect(() => npmPackage.parseNpmPackOutput(JSON.stringify([]))).toThrow('exactly one package');
+    expect(() => npmPackage.parseNpmPackOutput(JSON.stringify([packed, packed]))).toThrow(
+      'exactly one package',
+    );
+    expect(() => npmPackage.parseNpmPackOutput(JSON.stringify({ 'cloakbrowser-mcp': {} }))).toThrow(
+      'exactly one package',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Update `cloakbrowser` from `0.5.1` to `0.5.3`, including the upstream Preview release channel and the authenticated-proxy GeoIP, per-launch proxy identity, and Windows font-profile fixes.
- Add the startup-only `--release-channel <stable|preview>` option and `CLOAK_PLAYWRIGHT_MCP_RELEASE_CHANNEL`; Stable remains the default and HTTP initialize metadata cannot override it.
- Document the configuration in English and all supported configuration locales, and make package verification accept the `npm pack --json` formats emitted across the supported Node CI matrix.

## Checklist

- [x] I ran `npm run check` locally and it passed.
- [x] If I changed public behavior, I updated `README.md` and relevant docs in `docs/`.
- [x] If I changed local bridge tools, I updated `docs/tools.md`. (Not applicable: no local bridge tools changed.)
- [x] If I changed bridge configuration, I updated `docs/configuration.md`.
- [x] Upstream Playwright MCP tool schemas, descriptions, and responses are not copied or mutated.
- [x] I added/updated tests (unit and/or integration as appropriate).
- [x] I added an entry to `CHANGELOG.md` under `## [Unreleased]`.
- [x] I reviewed security implications and documented them below.

## Security review

The release channel is process-scoped at bridge startup; Streamable HTTP clients cannot set or override it through initialize metadata. Stable is the default. Preview remains subject to CloakBrowser's upstream Pro licensing; an explicit `CLOAKBROWSER_VERSION` pin takes precedence, and unavailable Preview builds fall back upstream to Stable. Signed binary verification and license handling remain upstream. Proxy credentials continue to pass unchanged to CloakBrowser for GeoIP resolution and are not logged. No upstream Playwright MCP tool-contract, filesystem, Docker, workflow, OIDC, secret, token, or registry-publishing behavior changed.

## Test evidence

- Passed: `npm run test:unit -- --run tests/unit/script-core-libs.test.ts` (185 tests).
- Passed: `npm run package:verify` with npm 12, including package installation and CLI verification.
- Passed: `npm run check` (209 tests, generated CLI E2E test, package metadata validation, and current documentation translations).
- Previously passed for the unchanged bridge runtime: `npm run bridge:compare`, `npm run docker:build`, `npm run docker:smoke`, `npm run docs:build`, and `npm run docs:seo:validate`.